### PR TITLE
FastAPI + Pydantic Dependency Fix

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = "Backend for Velour evaluation store"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}
-dependencies = ["fastapi[all]", "PyJWT[crypto]", "GeoAlchemy2", "psycopg2-binary", "SQLAlchemy>=2.0", "Pillow >= 9.1.0", "numpy", "python-dotenv", "motmetrics", "redis"]
+dependencies = ["fastapi[all] == 0.99.1", "PyJWT[crypto]", "GeoAlchemy2", "psycopg2-binary", "SQLAlchemy>=2.0", "Pillow >= 9.1.0", "numpy", "python-dotenv", "motmetrics", "redis"]
 
 [build-system]
 requires =  ["setuptools>=61.0"]


### PR DESCRIPTION
Essentially just locking fastapi[all] to version 0.99.1 until the migration to pydantic 2.0 happens.