### PR TITLE
remove trailing slash

### DIFF
--- a/api/velour_api/main.py
+++ b/api/velour_api/main.py
@@ -553,7 +553,7 @@ def get_evaluation_jobs_for_model(
 
 
 @app.get(
-    "/evaluations/",
+    "/evaluations",
     dependencies=[Depends(token_auth_scheme)],
     response_model_exclude_none=True,
     tags=["Evaluations"],


### PR DESCRIPTION
Trailing slash messes with the query params, the route will not be recognized by the server and return a 404