### PR TITLE
Bugfix - Label creation could not handle duplicates.

### DIFF
--- a/api/tests/functional-tests/backend/test_label.py
+++ b/api/tests/functional-tests/backend/test_label.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import Session
 from psycopg2.errors import UniqueViolation
 
 from velour_api.schemas import Label
-from velour_api.exceptions import LabelDoesNotExistError
 from velour_api.backend import models
 from velour_api.backend.core.label import create_labels, _get_existing_labels
 
@@ -55,8 +54,7 @@ def test__get_existing_labels(db: Session, simple_labels):
 
     # search for label that doesnt exist
     search = [Label(key="animal", value="elephant")]
-    with pytest.raises(LabelDoesNotExistError):
-        _get_existing_labels(db, search)
+    assert len(_get_existing_labels(db, search)) == 0
 
 
 def test__get_existing_labels_from_labels_with_common_values(
@@ -83,8 +81,7 @@ def test__get_existing_labels_from_labels_with_common_values(
 
     # search for label that doesnt exist
     search = [Label(key="animal", value="elephant")]
-    with pytest.raises(LabelDoesNotExistError):
-        _get_existing_labels(db, search)
+    assert len(_get_existing_labels(db, search)) == 0
 
     # search for labels (car_color, red) and (stoplight_color, green)
     # validates that key-value pairings are respected.

--- a/api/velour_api/exceptions.py
+++ b/api/velour_api/exceptions.py
@@ -227,16 +227,6 @@ class DatumDoesNotBelongToDatasetError(Exception):
         )
 
 
-""" Label """
-
-
-class LabelDoesNotExistError(Exception):
-    def __init__(self, key: str, value: str):
-        return super().__init__(
-            f"Label ({key}, {value}) does not exist."
-        )
-
-
 """ Misc. """
 
 


### PR DESCRIPTION
Label creation was allowing duplicates into the sqlalchemy bulk insert which would consistently throw exceptions when working with superclass labels.

Fixed by making this a set operation. 

Also removed check for input-output list parity as duplicates should be removed.