### PR TITLE
better layer caching when pip/deps dont change

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,6 @@ ARG VERSION="0.0.0-dev"
 RUN apt-get update && apt-get install build-essential libpq-dev -y
 
 COPY ./pyproject.toml /src/
-COPY ./velour_api /src/velour_api
 
 WORKDIR /src
 RUN python -m pip install -U pip
@@ -13,5 +12,5 @@ RUN python -m pip install -U pip
 # and then pass it to the build arg VERSION. this is so we don't need to install
 # git and put .git (which setuptools_scm needs to determine the version) in the container
 RUN SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} python -m pip install .
-
+COPY ./velour_api /src/velour_api
 CMD ["uvicorn", "velour_api.main:app", "--host", "0.0.0.0"]


### PR DESCRIPTION
Currently we 

1. Copy python files into container
2. Do pip install 

This causes a cache miss anytime we modify a python file and forces another pip install. Copying the python code after the pip install will cache hit when the python code changes but not the python deps. 