### PR TITLE
fixed object detection mAP

### DIFF
--- a/integration_tests/client/datatype/test_geospatial.py
+++ b/integration_tests/client/datatype/test_geospatial.py
@@ -107,7 +107,7 @@ def test_geospatial_filter(
         },
     )
     assert eval_job.wait_for_completion(timeout=30) == EvaluationStatus.DONE
-    assert len(eval_job.metrics) == 6
+    assert len(eval_job.metrics) == 9
 
     # passing in an incorrectly-formatted geojson dict should return a ValueError
     with pytest.raises(ValueError) as e:
@@ -138,7 +138,7 @@ def test_geospatial_filter(
             "operator": "intersect",
         }
     ]
-    assert len(eval_job.metrics) == 6
+    assert len(eval_job.metrics) == 9
 
     # filtering by model is allowed, this is the equivalent of requesting..
     # "Give me the dataset that model A has operated over."


### PR DESCRIPTION
A bug was reported where mAP was not performing as expected.

A model that returned 2 out of 5 classes correctly was outperforming the mAP of a model that returned 3 out of 5 classes.

This was caused by the omitting of groundtruth labels that did not have a matching prediction.