### PR TITLE
Fixing Docker Shortname to work with podman as well. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test-env:
 	docker compose -p velour --env-file ./api/.env.testing up --build -d
 
 dev-env:
-	docker compose -p velour -f docker-compose.yml --env-file ./api/.env.testing up --build
+	docker compose -p velour -f docker-compose.yml --env-file ./api/.env.testing up --build -d
 
 stop-env:
 	docker compose -p velour down
@@ -14,7 +14,7 @@ start-postgis-docker:
 	docker run -p 5432:5432 -e POSTGRES_PASSWORD=password -d postgis/postgis
 
 functional-tests:
-	POSTGRES_PASSWORD=password POSTGRES_HOST=localhost pytest -v ./api/tests/functional-tests
+	POSTGRES_PASSWORD=password POSTGRES_HOST=localhost POSTGRES_DB=velour POSTGRES_USERNAME=postgres POSTGRES_PORT=5432  pytest -v ./api/tests/functional-tests
 
 start-server:
 	POSTGRES_PASSWORD=password POSTGRES_HOST=localhost uvicorn velour_api.main:app --host 0.0.0.0

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -1,4 +1,4 @@
-FROM migrate/migrate
+FROM docker.io/migrate/migrate
 COPY . /migrations
 WORKDIR /migrations
 


### PR DESCRIPTION
Podman does  not resolve docker short names. using full path. 