### PR TITLE
rollback and close `db` if `db.execute` fails

### DIFF
--- a/api/velour_api/backend/database.py
+++ b/api/velour_api/backend/database.py
@@ -55,7 +55,7 @@ def make_session() -> Session:
     """Creates a session and enables the gdal drivers (needed for raster support)"""
     db = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
     try:
-        db.execute(text("SETa postgis.gdal_enabled_drivers = 'ENABLE_ALL';"))
+        db.execute(text("SET postgis.gdal_enabled_drivers = 'ENABLE_ALL';"))
         db.commit()
     except Exception as e:
         db.rollback()


### PR DESCRIPTION
i noticed a weird, hard to replicate issue where the number of connections in postgres would be growing (seemingly unbounded). i think this may be due to `make_session` having retries and if an attempt fails the created session is not closed and another one is created