### PR TITLE
Use heapify instead of sort for heap

### DIFF
--- a/api/valor_api/backend/metrics/detection.py
+++ b/api/valor_api/backend/metrics/detection.py
@@ -38,7 +38,7 @@ def _calculate_101_pt_interp(precisions, recalls) -> float:
     data.sort(key=lambda x: x[1])
     # negative is because we want a max heap
     prec_heap = [[-precision, i] for i, (precision, _) in enumerate(data)]
-    prec_heap.sort()
+    heapq.heapify(prec_heap)
 
     cutoff_idx = 0
     ret = 0


### PR DESCRIPTION
Use linear time `heapq.heapify` to create heap.

Chariot PR with the same change: https://github.com/Striveworks/chariot/pull/5779
Slack discussion: https://striveworks.slack.com/archives/C0442QPU63V/p1708989167452269