### PR TITLE
Removed raster dependency on datum

### DIFF
--- a/api/tests/unit-tests/schemas/test_core.py
+++ b/api/tests/unit-tests/schemas/test_core.py
@@ -359,8 +359,21 @@ def test_annotation_with_scores(
         )
 
 
-def test_groundtruth(metadata, groundtruth_annotations):
+def test_groundtruth(metadata, groundtruth_annotations, raster):
     # valid
+    schemas.GroundTruth(
+        datum=schemas.Datum(
+            uid="uid",
+            dataset_name="name",
+        ),
+        annotations=[
+            schemas.Annotation(
+                task_type=enums.TaskType.SEMANTIC_SEGMENTATION,
+                labels=[schemas.Label(key="k1", value="v1")],
+                raster=raster,
+            )
+        ],
+    )
     gt = schemas.GroundTruth(
         datum=schemas.Datum(
             uid="uid",

--- a/integration_tests/client/datasets/test_groundtruth.py
+++ b/integration_tests/client/datasets/test_groundtruth.py
@@ -178,7 +178,7 @@ def test_create_gt_segs_as_polys_or_masks(
 def test_add_groundtruth(
     client: Client,
     dataset_name: str,
-    gt_semantic_segs_error: GroundTruth,
+    gt_semantic_segs_mismatch: GroundTruth,
 ):
     dataset = Dataset.create(dataset_name)
 
@@ -197,10 +197,8 @@ def test_add_groundtruth(
             )
         )
 
-    with pytest.raises(ClientException) as exc_info:
-        dataset.add_groundtruth(gt_semantic_segs_error)
-
-    assert "raster and image to have" in str(exc_info)
+    # make sure raster is not dependent on datum metadata
+    dataset.add_groundtruth(gt_semantic_segs_mismatch)
 
     client.delete_dataset(dataset_name, timeout=30)
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -443,11 +443,9 @@ def gt_semantic_segs2_mask(img2: ImageMetadata) -> GroundTruth:
 
 
 @pytest.fixture
-def gt_semantic_segs_error(img1: ImageMetadata) -> GroundTruth:
+def gt_semantic_segs_mismatch(img1: ImageMetadata) -> GroundTruth:
     mask = _generate_mask(height=100, width=100)
     raster = Raster.from_numpy(mask)
-
-    # expected to throw an error since the mask size differs from the image size
     return GroundTruth(
         datum=img1.to_datum(),
         annotations=[


### PR DESCRIPTION
Raster currently requires the datum to encode a matching height and width. This relationship is unintuitive and causes unexpected failures when there is nothing wrong with a users input.