### PR TITLE
Logging HTTP 500 fix

### DIFF
--- a/api/valor_api/logging.py
+++ b/api/valor_api/logging.py
@@ -52,14 +52,14 @@ async def handle_http_exception(
 
 
 async def handle_unhandled_exception(
-    request: Request, exc: RequestValidationError
+    request: Request, exc: Exception
 ) -> Union[JSONResponse, Response]:
     logger.error(
         "Valor unhandled exception",
         method=request.method,
         path=request.url.path,
         hostname=request.url.hostname,
-        exception=str(exc),
+        exc_info=exc,
     )
     return JSONResponse(
         content={"status": 500, "detail": "Internal Server Error"},

--- a/api/valor_api/main.py
+++ b/api/valor_api/main.py
@@ -11,6 +11,7 @@ from valor_api import __version__ as api_version
 from valor_api import api_utils, auth, crud, enums, exceptions, logger, schemas
 from valor_api.backend import database
 from valor_api.logging import (
+    handle_http_exception,
     handle_request_validation_exception,
     handle_unhandled_exception,
     log_endpoint_middleware,
@@ -32,6 +33,7 @@ app.middleware("http")(log_endpoint_middleware)
 app.exception_handler(RequestValidationError)(
     handle_request_validation_exception
 )
+app.exception_handler(HTTPException)(handle_http_exception)
 app.exception_handler(Exception)(handle_unhandled_exception)
 
 


### PR DESCRIPTION
HTTPExceptions were not being correctly logged.  Add logging for those with status >= 500.  This is tricky because HTTPExceptions are not necessarily errors -- I don't think we should log 404 "model not found" stack traces, for example.

The `structlog` exception logging is pretty verbose.  Here's the logging we get if `raise Exception("Test!")` is inserted inside the `try:except:` block in `api.main.get_evaluations`:

```
{
  "method": "GET",
  "path": "/evaluations",
  "hostname": "localhost",
  "event": "Valor HTTP exception",
  "level": "error",
  "timestamp": "2024-03-05T19:00:18.799050Z",
  "exception": [
    {
      "exc_type": "HTTPException",
      "exc_value": "500: {\"name\": \"NotImplementedError\", \"detail\": \"Test!\", \"timestamp\": 1709665218.797421}",
      "syntax_error": null,
      "is_cause": false,
      "frames": [
        {
          "filename": "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py",
          "lineno": 53,
          "name": "wrapped_app",
          "line": "",
          "locals": {
            "scope": "\"{'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_versio\"+1372",
            "receive": "'<function BaseHTTPMiddleware.__call__.<locals>.call_next.<locals>.receive_or_dis'+26",
            "sender": "'<function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0'+14",
            "exc": "'HTTPException(status_code=500, detail=\\'{\"name\": \"NotImplementedError\", \"detail\":'+45",
            "handler": "<function handle_http_exception at 0x7f0d55f84310>",
            "response_started": "False",
            "send": "'<function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0'+14",
            "app": "<function request_response.<locals>.app.<locals>.app at 0x7f0d5576d090>",
            "conn": "<starlette.requests.Request object at 0x7f0d55761d50>",
            "exception_handlers": "\"{<class 'starlette.exceptions.HTTPException'>: <function http_exception_handler \"+562",
            "status_handlers": "{}"
          }
        },
        {
          "filename": "/usr/local/lib/python3.10/site-packages/starlette/routing.py",
          "lineno": 74,
          "name": "app",
          "line": "",
          "locals": {
            "scope": "\"{'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_versio\"+1372",
            "receive": "'<function BaseHTTPMiddleware.__call__.<locals>.call_next.<locals>.receive_or_dis'+26",
            "send": "'<function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0'+14",
            "func": "<function get_request_handler.<locals>.app at 0x7f0d55b81c60>",
            "request": "<starlette.requests.Request object at 0x7f0d55761d50>"
          }
        },
        // Several entries clipped
        {
          "filename": "/src/valor_api/main.py",
          "lineno": 1049,
          "name": "get_evaluations",
          "line": "",
          "locals": {
            "datasets": "None",
            "models": "abc",
            "evaluation_ids": "None",
            "db": "<sqlalchemy.orm.session.Session object at 0x7f0d55760ee0>",
            "model_names": "['abc']",
            "dataset_names": "None",
            "evaluation_ids_str": "None",
            "evaluation_ids_ints": "None"
          }
        }
      ]
    },
    {
      "exc_type": "NotImplementedError",
      "exc_value": "Test!",
      "syntax_error": null,
      "is_cause": false,
      "frames": [
        {
          "filename": "/src/valor_api/main.py",
          "lineno": 1041,
          "name": "get_evaluations",
          "line": "",
          "locals": {
            "datasets": "None",
            "models": "abc",
            "evaluation_ids": "None",
            "db": "<sqlalchemy.orm.session.Session object at 0x7f0d55760ee0>",
            "model_names": "['abc']",
            "dataset_names": "None",
            "evaluation_ids_str": "None",
            "evaluation_ids_ints": "None"
          }
        }
      ]
    }
  ]
}
{
  "method": "GET",
  "path": "/evaluations",
  "hostname": "localhost",
  "status": 500,
  "event": "Valor API Call",
  "level": "info",
  "timestamp": "2024-03-05T19:00:18.801580Z"
}
```

After the exception is logged, we return stuff to the client.  In the above example, the client shows the following at the repl.  Note the JSON string
that is the `detail` of the `HTTPException`.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/rsbowman/dev/velour/client/valor/client.py", line 865, in get_evaluations
    return self._requests_get_rel_host(endpoint).json()
  File "/home/rsbowman/dev/velour/client/valor/client.py", line 323, in _requests_get_rel_host
    return self._requests_wrapper(
  File "/home/rsbowman/dev/velour/client/valor/client.py", line 302, in _requests_wrapper
    raise ClientException(resp)
valor.exceptions.ClientException: {"name": "NotImplementedError", "detail": "Test!", "timestamp": 1709668108.686037}
```
