### PR TITLE
patch api dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.10-slim
+FROM python:3.10-alpine
 
 ARG VERSION="0.0.0-dev"
 
-RUN apt-get update && apt-get install build-essential libpq-dev -y
+RUN apk add --update --no-cache build-base libpq-dev
 
 COPY ./pyproject.toml /src/
 
@@ -13,4 +13,6 @@ RUN python -m pip install -U pip
 # git and put .git (which setuptools_scm needs to determine the version) in the container
 RUN SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} python -m pip install .
 COPY ./valor_api /src/valor_api
+RUN apk del build-base
+USER 65532:65532
 CMD ["uvicorn", "valor_api.main:app", "--host", "0.0.0.0", "--log-level", "warning"]


### PR DESCRIPTION

Fixes:
- Switch to non-root user
- Switch to Python Alpine base for fewer vulnerabilities. 

Container logs after the patch appear to be the same.

```
/usr/local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_names" has conflict with protected namespace "model_".
2024-03-18T20:23:40.725374310Z 
2024-03-18T20:23:40.725382315Z You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
2024-03-18T20:23:40.725388777Z   warnings.warn(
2024-03-18T20:23:40.725392254Z /usr/local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_metadata" has conflict with protected namespace "model_".
2024-03-18T20:23:40.725396261Z 
2024-03-18T20:23:40.725399427Z You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
2024-03-18T20:23:40.725402833Z   warnings.warn(
2024-03-18T20:23:40.810667023Z {"event": "API server 0.0.0.dev0 started WITHOUT authentication", "level": "info", "timestamp": "2024-03-18T20:23:40.810494Z"}
```