### PR TITLE
Fix bug where psql isn't ready for migration

### DIFF
--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /migrations
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+RUN apk --update add postgresql-client
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["up"]

--- a/migrations/entrypoint.sh
+++ b/migrations/entrypoint.sh
@@ -13,7 +13,7 @@ WAIT_SECONDS=3
 
 wait_for_postgres() {
   retries=0
-  until nc -z -w 1 $POSTGRES_HOST $POSTGRES_PORT || [ $retries -eq $MAX_RETRIES ]; do
+  until PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USERNAME -c "select 1" -d $POSTGRES_DB >& /dev/null || [ $retries -eq $MAX_RETRIES ]; do
     echo "Waiting for PostgreSQL to be ready... (Retry $((retries+1)) of $MAX_RETRIES)"
     sleep $WAIT_SECONDS
     retries=$((retries+1))


### PR DESCRIPTION
## Problem

Today, calling `make start-postgres-docker && make run-migrations` fails with `error: EOF`. The issue is that postgres isn't actually ready to handle database requests when Docker opens the port; see [psql issue here for more details](https://github.com/docker-library/postgres/issues/146#issuecomment-215619771).

## Improvement

Change the `wait_for_postgres` command to wait until `psql` is actually ready to start the migration process.

## Acknowledgements
Thank you to Jordan for finding the GitHub thread and solution mentioned above!