### PR TITLE
send back created_at for evaluations

### DIFF
--- a/api/tests/functional-tests/backend/core/test_evaluation.py
+++ b/api/tests/functional-tests/backend/core/test_evaluation.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from sqlalchemy.orm import Session
 
@@ -339,6 +341,7 @@ def test_fetch_evaluation_from_id(
         fetched_evaluation.parameters["task_type"]
         == enums.TaskType.SEMANTIC_SEGMENTATION
     )
+    assert isinstance(fetched_evaluation.created_at, datetime.datetime)
 
 
 def test_get_evaluations(

--- a/api/tests/functional-tests/crud/test_create_delete.py
+++ b/api/tests/functional-tests/crud/test_create_delete.py
@@ -1251,8 +1251,7 @@ def test_create_detection_metrics(
     assert model_evals[0] == schemas.EvaluationResponse(
         model_name=model_name,
         datum_filter=schemas.Filter(
-            label_keys=["class"],
-            dataset_names=[dataset_name],
+            label_keys=["class"], dataset_names=[dataset_name]
         ),
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.OBJECT_DETECTION,
@@ -1268,6 +1267,7 @@ def test_create_detection_metrics(
         ignored_pred_labels=[
             schemas.Label(key="class", value="3", score=None)
         ],
+        created_at=model_evals[0].created_at,
     )
     assert model_evals[1] == schemas.EvaluationResponse(
         model_name=model_name,
@@ -1297,6 +1297,7 @@ def test_create_detection_metrics(
         confusion_matrices=[],
         missing_pred_labels=[],
         ignored_pred_labels=[],
+        created_at=model_evals[1].created_at,
     )
 
 

--- a/api/tests/unit-tests/schemas/test_evaluation.py
+++ b/api/tests/unit-tests/schemas/test_evaluation.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from pydantic import ValidationError
 
@@ -155,6 +157,7 @@ def test_EvaluationResponse():
         status=enums.EvaluationStatus.DONE,
         metrics=[],
         confusion_matrices=[],
+        created_at=datetime.now(),
     )
 
     # test missing evaluation_id
@@ -169,6 +172,7 @@ def test_EvaluationResponse():
             status=enums.EvaluationStatus.DONE,
             metrics=[],
             confusion_matrices=[],
+            created_at=datetime.now(),
         )
 
     # test missing model name
@@ -183,6 +187,7 @@ def test_EvaluationResponse():
             status=enums.EvaluationStatus.DONE,
             metrics=[],
             confusion_matrices=[],
+            created_at=datetime.now(),
         )
 
     # test missing EvaluationParameters
@@ -195,6 +200,7 @@ def test_EvaluationResponse():
             status=enums.EvaluationStatus.DONE,
             metrics=[],
             confusion_matrices=[],
+            created_at=datetime.now(),
         )
 
     # test missing EvaluationStatus
@@ -209,4 +215,5 @@ def test_EvaluationResponse():
             status=None,  # type: ignore - purposefully throwing error
             metrics=[],
             confusion_matrices=[],
+            created_at=datetime.now(),
         )

--- a/api/tests/unit-tests/test_main.py
+++ b/api/tests/unit-tests/test_main.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -943,6 +944,7 @@ def test_post_detection_metrics(client: TestClient):
         confusion_matrices=[],
         missing_pred_labels=[],
         ignored_pred_labels=[],
+        created_at=datetime.now(),
     ).model_dump()
 
     example_json = schemas.EvaluationRequest(
@@ -975,6 +977,7 @@ def test_post_clf_metrics(client: TestClient):
         status=EvaluationStatus.PENDING,
         metrics=[],
         confusion_matrices=[],
+        created_at=datetime.now(),
     ).model_dump()
 
     example_json = schemas.EvaluationRequest(
@@ -1007,6 +1010,7 @@ def test_post_semenatic_segmentation_metrics(client: TestClient):
         confusion_matrices=[],
         missing_pred_labels=[],
         ignored_pred_labels=[],
+        created_at=datetime.now(),
     ).model_dump()
 
     example_json = schemas.EvaluationRequest(

--- a/api/valor_api/backend/core/evaluation.py
+++ b/api/valor_api/backend/core/evaluation.py
@@ -628,6 +628,7 @@ def get_evaluation_requests_from_model(
             datum_filter=eval_.datum_filter,
             parameters=eval_.parameters,
             status=eval_.status,  # type: ignore - must be str in psql
+            created_at=eval_.created_at.replace(tzinfo=timezone.utc),
         )
         for eval_ in evaluations
     ]

--- a/api/valor_api/backend/core/evaluation.py
+++ b/api/valor_api/backend/core/evaluation.py
@@ -1,3 +1,4 @@
+from datetime import timezone
 from typing import Sequence
 
 from sqlalchemy import and_, func, or_, select, update
@@ -286,6 +287,7 @@ def _create_response(
             )
             for matrix in confusion_matrices
         ],
+        created_at=evaluation.created_at.replace(tzinfo=timezone.utc),
         **kwargs,
     )
 

--- a/api/valor_api/schemas/evaluation.py
+++ b/api/valor_api/schemas/evaluation.py
@@ -149,6 +149,8 @@ class EvaluationResponse(BaseModel):
         Any parameters used by the evaluation method.
     status : str
         The status of the evaluation.
+    created_at: datetime.datetime
+        The time the evaluation was created.
     metrics : List[Metric]
         A list of metrics associated with the evaluation.
     confusion_matrices: List[ConfusionMatrixResponse]
@@ -157,7 +159,6 @@ class EvaluationResponse(BaseModel):
         A list of ground truth labels that aren't associated with any predictions.
     ignored_pred_labels: List[Label], optional
         A list of prediction labels that aren't associated with any ground truths.
-
     """
 
     id: int
@@ -165,11 +166,11 @@ class EvaluationResponse(BaseModel):
     datum_filter: Filter
     parameters: EvaluationParameters
     status: EvaluationStatus
+    created_at: datetime.datetime
     metrics: list[Metric] | None = None
     confusion_matrices: list[ConfusionMatrixResponse] | None = None
     ignored_pred_labels: list[Label] | None = None
     missing_pred_labels: list[Label] | None = None
-    created_at: datetime.datetime
 
     # pydantic setting
     model_config = ConfigDict(

--- a/api/valor_api/schemas/evaluation.py
+++ b/api/valor_api/schemas/evaluation.py
@@ -1,3 +1,5 @@
+import datetime
+
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from valor_api.enums import AnnotationType, EvaluationStatus, TaskType
@@ -167,6 +169,7 @@ class EvaluationResponse(BaseModel):
     confusion_matrices: list[ConfusionMatrixResponse] | None = None
     ignored_pred_labels: list[Label] | None = None
     missing_pred_labels: list[Label] | None = None
+    created_at: datetime.datetime
 
     # pydantic setting
     model_config = ConfigDict(

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import json
 import time
 import warnings
@@ -858,6 +859,7 @@ class Evaluation:
         status: EvaluationStatus,
         metrics: List[Dict],
         confusion_matrices: List[Dict],
+        created_at: str,
         **kwargs,
     ):
         self.id = id
@@ -878,6 +880,9 @@ class Evaluation:
         self.kwargs = kwargs
         self.ignored_pred_labels: Optional[List[Label]] = None
         self.missing_pred_labels: Optional[List[Label]] = None
+        self.created_at = datetime.datetime.strptime(
+            created_at, "%Y-%m-%dT%H:%M:%S.%fZ"
+        ).replace(tzinfo=datetime.timezone.utc)
 
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/integration_tests/client/metrics/test_classification.py
+++ b/integration_tests/client/metrics/test_classification.py
@@ -2,7 +2,7 @@
 that is no auth
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -228,11 +228,6 @@ def test_evaluate_tabular_clf(
         model.add_prediction(dataset, pd)
 
     # test model finalization
-    print(
-        client.get_model_status(
-            dataset_name=dataset_name, model_name=model_name
-        )
-    )
     with pytest.raises(ClientException) as exc_info:
         model.evaluate_classification(dataset)
     assert "has not been finalized" in str(exc_info)
@@ -357,6 +352,11 @@ def test_evaluate_tabular_clf(
     assert len(results[0].datum_filter.dataset_names) == 1
     assert results[0].datum_filter.dataset_names[0] == dataset_name
     assert results[0].model_name == model_name
+    assert isinstance(results[0].created_at, datetime)
+    # check created at is within a minute of the current time
+    assert (datetime.now(timezone.utc) - results[0].created_at) < timedelta(
+        minutes=1
+    )
 
     metrics_from_eval_settings_id = results[0].metrics
     assert len(metrics_from_eval_settings_id) == len(expected_metrics)

--- a/ts-client/src/ValorClient.ts
+++ b/ts-client/src/ValorClient.ts
@@ -39,6 +39,7 @@ export type Evaluation = {
   status: 'pending' | 'running' | 'done' | 'failed' | 'deleting';
   metrics: Metric[];
   confusion_matrices: any[];
+  created_at: Date;
 };
 
 const metadataDictToString = (input: { [key: string]: string | number }): string => {
@@ -230,6 +231,17 @@ export class ValorClient {
   }
 
   /**
+   * Takes data from the backend response and converts it to an Evaluation object
+   * by converting the datetime string to a `Date` object
+   */
+  private unmarshalEvaluation(evaluation: any): Evaluation {
+    return {
+      ...evaluation,
+      created_at: new Date(evaluation.created_at)
+    };
+  }
+
+  /**
    * Creates a new evaluation or gets an existing one if an evaluation with the
    * same parameters already exists.
    *
@@ -249,7 +261,7 @@ export class ValorClient {
       datum_filter: { dataset_names: [dataset] },
       parameters: { task_type: taskType }
     });
-    return response.data[0];
+    return this.unmarshalEvaluation(response.data[0]);
   }
 
   /**
@@ -272,7 +284,7 @@ export class ValorClient {
       datum_filter: { dataset_names: [dataset] },
       parameters: { task_type: taskType }
     });
-    return response.data;
+    return response.data.map(this.unmarshalEvaluation);
   }
 
   /**
@@ -285,7 +297,7 @@ export class ValorClient {
    */
   private async getEvaluations(queryParams: object): Promise<Evaluation[]> {
     const response = await this.client.get('/evaluations', { params: queryParams });
-    return response.data;
+    return response.data.map(this.unmarshalEvaluation);
   }
 
   /**

--- a/ts-client/tests/ValorClient.test.ts
+++ b/ts-client/tests/ValorClient.test.ts
@@ -140,6 +140,12 @@ test('evaluation methods', async () => {
     }
     expect(evaluation.metrics.length).toBeGreaterThan(0);
     expect(evaluation.datum_filter.dataset_names).toStrictEqual([datasetName]);
+    // check the date is within one minute of the current time
+    console.log(`evaluation.created_at: ${evaluation.created_at}`);
+    const now = new Date();
+    console.log(`now: ${now}`);
+    const timeDiff = Math.abs(now.getTime() - evaluation.created_at.getTime());
+    expect(timeDiff).toBeLessThan(60 * 1000);
   };
   // evaluate against all models and datasets
   await Promise.all(


### PR DESCRIPTION
this PR updates the evaluations endpoints to return the created_at time and updates the python and type script clients to accept this new field