### PR TITLE
Discussion: Detection metric averaging

### DIFF
--- a/api/tests/functional-tests/backend/metrics/test_detection.py
+++ b/api/tests/functional-tests/backend/metrics/test_detection.py
@@ -684,7 +684,7 @@ def test__compute_detection_metrics(
         # mAR METRICS
         {
             "ious": iou_thresholds,
-            "value": 0.652,
+            "value": 0.543,
         },
     ]
 
@@ -864,7 +864,7 @@ def test__compute_detection_metrics_with_rasters(
         # mAR METRICS
         {
             "ious": iou_thresholds,
-            "value": 0.667,
+            "value": 0.5,
         },
     ]
 

--- a/api/valor_api/backend/metrics/detection.py
+++ b/api/valor_api/backend/metrics/detection.py
@@ -724,7 +724,7 @@ def _average_ignore_minus_one(a):
         if x != -1:
             div0_flag = False
             num += x
-            denom += 1
+        denom += 1
     return -1 if div0_flag else num / denom
 
 

--- a/api/valor_api/backend/metrics/detection.py
+++ b/api/valor_api/backend/metrics/detection.py
@@ -719,13 +719,11 @@ def _compute_detection_metrics_averaged_over_ious_from_aps(
 def _average_ignore_minus_one(a):
     """Average a list of metrics, ignoring values of -1"""
     num, denom = 0.0, 0.0
-    div0_flag = True
     for x in a:
         if x != -1:
-            div0_flag = False
             num += x
         denom += 1
-    return -1 if div0_flag else num / denom
+    return num / denom if denom else -1
 
 
 def _compute_mean_ar_metrics(

--- a/integration_tests/client/metrics/test_detection.py
+++ b/integration_tests/client/metrics/test_detection.py
@@ -989,7 +989,11 @@ def test_evaluate_detection_with_label_maps(
             "parameters": {"iou": 0.6},
             "value": 0.100990099009901,
         },
-        {"type": "mAR", "parameters": {"ious": [0.1, 0.6]}, "value": 0.1},
+        {
+            "type": "mAR",
+            "parameters": {"ious": [0.1, 0.6]},
+            "value": 0.07142857142857142,
+        },
         {
             "type": "APAveragedOverIOUs",
             "parameters": {"ious": [0.1, 0.6]},
@@ -1186,7 +1190,7 @@ def test_evaluate_detection_with_label_maps(
         {
             "type": "mAR",
             "parameters": {"ious": [0.1, 0.6]},
-            "value": 0.27777777777777773,
+            "value": 0.20833333333333331,
         },
         {
             "type": "APAveragedOverIOUs",


### PR DESCRIPTION
### Issue Description

See `api/tests/functional-tests/backend/metrics/test_detection.py::test__compute_detection_metrics`.

I am using mAR to test, but this should apply to mAP as well.

AR Metrics
Label (class, 2) => 0.45
Label (class, 3) => -1 # Null output, count as zero?
Label (class, 49) => 0.58
Label (class, 0) => 0.78
Label (class, 1) => 0.8
Label (class, 1) => 0.65

mAR = 0.652

The issue arises if we manually calculate mAR:

mAR = (0.45 + 0.0 + 0.58 + 0.78 + 0.8 + 0.65) / 6 labels
mAR = 0.543


### Expected Behavior / Discussion

The expected behavior is not straightforward and depends on perspective. There are four options in calculating average metrics.

1. Ignore all nulls (current behavior)
2. Ignore only null predictions, preserving groundtruth label set.
3. Ignore only null groundtruths, preserving prediction label set.
4. Allow all metrics returning null to be counted in averaging denominator. (proposed behavior)