### PR TITLE
Bugfix: Raster.from_geometry with decimal values

### DIFF
--- a/api/tests/functional-tests/backend/core/test_geometry.py
+++ b/api/tests/functional-tests/backend/core/test_geometry.py
@@ -445,133 +445,24 @@ def test_create_raster_from_polygons_with_decimal_coordinates(
     )
     assert groundtruth.annotations[0].raster
     # note that postgis rasterization is lossy
-    assert (
-        groundtruth.annotations[0].raster.array
-        == np.array(
+    arr = (
+        np.array(
             [
-                [
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    False,
-                    False,
-                    True,
-                    True,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    False,
-                    True,
-                    True,
-                    True,
-                    True,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    True,
-                    True,
-                    True,
-                    True,
-                    True,
-                    True,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    False,
-                    True,
-                    True,
-                    True,
-                    True,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    False,
-                    False,
-                    True,
-                    True,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
-                [
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                ],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 1, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+                [0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+                [0, 0, 0, 1, 1, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             ]
         )
-    ).all()
+        == 1
+    )
+    assert (groundtruth.annotations[0].raster.array == arr).all()
 
     # convert raster into a polygon
     polygon_subquery = (

--- a/api/tests/functional-tests/backend/core/test_geometry.py
+++ b/api/tests/functional-tests/backend/core/test_geometry.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from valor_api import enums, schemas
 from valor_api.backend import models
-from valor_api.backend.core import fetch_dataset
+from valor_api.backend.core import fetch_dataset, get_groundtruth
 from valor_api.backend.core.geometry import (
     _convert_polygon_to_box,
     _convert_raster_to_box,
@@ -20,10 +20,12 @@ from valor_api.backend.core.geometry import (
 from valor_api.crud import create_dataset, create_groundtruth
 from valor_api.schemas import (
     Annotation,
+    BasicPolygon,
     BoundingBox,
     Datum,
     GroundTruth,
     MultiPolygon,
+    Point,
     Polygon,
     Raster,
 )
@@ -286,7 +288,7 @@ def test_convert_polygon_to_box(
     assert converted_box == bbox
 
 
-def test_create_segmentations_from_polygons(
+def test_create_raster_from_polygons(
     db: Session,
     create_segmentation_dataset_from_geometries: str,
     bbox: BoundingBox,
@@ -389,3 +391,201 @@ def test_create_segmentations_from_polygons(
     assert (
         polygons[2] == polygon
     )  # uncorrupted raster converts to correct polygon
+
+
+def test_create_raster_from_polygons_with_decimal_coordinates(
+    db: Session,
+    dataset_name: str,
+    polygon: Polygon,
+    raster: Raster,
+):
+    # alter polygon to be offset by 0.1
+    assert (
+        polygon.wkt()
+        == "POLYGON ((4.0 0.0, 1.0 3.0, 4.0 6.0, 7.0 3.0, 4.0 0.0))"
+    )
+    polygon.boundary = BasicPolygon(
+        points=[
+            Point(x=point.x + 0.1, y=point.y + 0.5)
+            for point in polygon.boundary.points
+        ]
+    )
+    assert (
+        polygon.wkt()
+        == "POLYGON ((4.1 0.5, 1.1 3.5, 4.1 6.5, 7.1 3.5, 4.1 0.5))"
+    )
+
+    # create raster annotation
+    datum = Datum(
+        uid="uid1",
+        dataset_name=dataset_name,
+    )
+    task_type = enums.TaskType.OBJECT_DETECTION
+    labels = [schemas.Label(key="k1", value="v1")]
+    groundtruth = GroundTruth(
+        datum=datum,
+        annotations=[
+            Annotation(
+                task_type=task_type,
+                labels=labels,
+                raster=Raster(
+                    mask=raster.mask,
+                    geometry=polygon,
+                ),
+            ),
+        ],
+    )
+    dataset = schemas.Dataset(name=dataset_name)
+    create_dataset(db=db, dataset=dataset)
+    create_groundtruth(db=db, groundtruth=groundtruth)
+
+    # retrieve the raster from the database to see if it has been converted.
+    groundtruth = get_groundtruth(
+        db=db, dataset_name=dataset_name, datum_uid="uid1"
+    )
+    assert groundtruth.annotations[0].raster
+    # note that postgis rasterization is lossy
+    assert (
+        groundtruth.annotations[0].raster.array
+        == np.array(
+            [
+                [
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    False,
+                    False,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    False,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    False,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    False,
+                    False,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+            ]
+        )
+    ).all()
+
+    # convert raster into a polygon
+    polygon_subquery = (
+        select(models.Annotation.polygon)
+        .where(models.Annotation.polygon.isnot(None))
+        .subquery()
+    )
+    assert len(db.query(polygon_subquery).all()) == 0
+    q = _convert_raster_to_polygon([])
+    db.execute(q)
+    assert len(db.query(polygon_subquery).all()) == 1
+
+    # check polygon in WKT format
+    db_polygon = db.scalar(select(func.ST_AsText(models.Annotation.polygon)))
+    assert db_polygon
+    # note that postgis rasterization is lossy
+    assert db_polygon == "POLYGON((3 1,1 3,3 5,4 5,6 3,4 1,3 1))"

--- a/api/valor_api/schemas/geometry.py
+++ b/api/valor_api/schemas/geometry.py
@@ -10,6 +10,7 @@ from geoalchemy2.functions import (
     ST_GeomFromText,
     ST_MakeEmptyRaster,
     ST_MapAlgebra,
+    ST_SnapToGrid,
 )
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import ScalarSelect, select
@@ -1160,7 +1161,10 @@ class Raster(BaseModel):
                 "8BUI",
             )
             geom_raster = ST_AsRaster(
-                ST_GeomFromText(self.geometry.wkt()),
+                ST_SnapToGrid(
+                    ST_GeomFromText(self.geometry.wkt()),
+                    1.0,
+                ),
                 1.0,  # scalex
                 1.0,  # scaley
                 "8BUI",  # pixeltype
@@ -1168,7 +1172,6 @@ class Raster(BaseModel):
                 0,  # nodataval
             )
             return select(
-                # geom_raster,
                 ST_MapAlgebra(
                     empty_raster,
                     geom_raster,


### PR DESCRIPTION
### Reproducible Example

```python
# construct a raster created using a geometry that has decimal point values
from valor.schemas import Polygon, Raster
Raster.from_geometry(
  geometry=Polygon([[(0.1, 0.1), (0.9, 0.9), (0.9, 0.1), (0.1, 0.1)]]),
  height=10,
  width=10,
)
# when this is uploaded to the API, the ST_MapAlegebra function fails rasing the following error message.
psycopg2.errors.InternalError_: rt_raster_iterator: The set of rasters provided (custom extent included, if appropriate) do not have the same alignment
```


### Issue Description

Rasters are constructed using the following steps...

1. Convert geometry to a raster.

```
geom_raster = ST_AsRaster(
    ST_GeomFromText(self.geometry.wkt()),
    1.0,  # scalex
    1.0,  # scaley
    "8BUI",  # pixeltype
    1,  # value
    0,  # nodataval
)
```

2. Create the bitmask to map onto.

```
empty_raster = ST_AddBand(
    ST_MakeEmptyRaster(
        self.width,
        self.height,
        0,  # upperleftx
        0,  # upperlefty
        1,  # scalex
        1,  # scaley
        0,  # skewx
        0,  # skewy
        0,  # srid
    ),
    "8BUI",
)
```

3. Map the geometry-raster onto the empty raster.

This is where the error occurs. Rasters constructed from geometries with decimal values are considered out of alignment with the integer-based coordinates of the empty base raster.

```
return select(
    # geom_raster,
    ST_MapAlgebra(
        empty_raster,
        geom_raster,
        "[rast2]",
        "8BUI",
        "UNION",
    )
).scalar_subquery()
```

### Solution

The raster-geometry should approximate the pixel coordinates. This can be done using `ST_SnapToGrid` which will round coordinate values to the nearest integer.