### PR TITLE
moved label key validation outside of computation

### DIFF
--- a/api/valor_api/backend/core/evaluation.py
+++ b/api/valor_api/backend/core/evaluation.py
@@ -11,6 +11,35 @@ from valor_api.backend import core, models
 from valor_api.backend.query import Query
 
 
+def _validate_classification_task(
+    db: Session,
+    evaluation: models.Evaluation,
+):
+    """
+    Validate that a classification evaluation is possible.
+
+    Parameters
+    ----------
+    db : Session
+        The database session.
+    evaluation : models.Evaluation
+        The uncommitted evaluation row.
+    """
+    # unpack filters and params
+    groundtruth_filter = schemas.Filter(**evaluation.datum_filter)
+    prediction_filter = groundtruth_filter.model_copy()
+    prediction_filter.model_names = [evaluation.model_name]
+    parameters = schemas.EvaluationParameters(**evaluation.parameters)
+
+    # check that prediction label keys match ground truth label keys
+    core.validate_matching_label_keys(
+        db=db,
+        label_map=parameters.label_map,
+        groundtruth_filter=groundtruth_filter,
+        prediction_filter=prediction_filter,
+    )
+
+
 def _create_dataset_expr_from_list(
     dataset_names: list[str],
 ) -> BinaryExpression | None:
@@ -448,6 +477,14 @@ def create_or_get_evaluations(
                 parameters=subrequest.parameters.model_dump(),
                 status=enums.EvaluationStatus.PENDING,
             )
+
+            # validation
+            if (
+                subrequest.parameters.task_type
+                == enums.TaskType.CLASSIFICATION
+            ):
+                _validate_classification_task(db=db, evaluation=evaluation)
+
             created_rows.append(evaluation)
 
     try:

--- a/api/valor_api/backend/metrics/classification.py
+++ b/api/valor_api/backend/metrics/classification.py
@@ -833,14 +833,6 @@ def _compute_clf_metrics(
         evaluation_type=enums.TaskType.CLASSIFICATION,
     )
 
-    # check that prediction label keys match ground truth label keys
-    core.validate_matching_label_keys(
-        db=db,
-        label_map=label_map,
-        groundtruth_filter=groundtruth_filter,
-        prediction_filter=prediction_filter,
-    )
-
     # compute metrics and confusion matrix for each grouper id
     confusion_matrices, metrics = [], []
     for grouper_key in grouper_mappings[

--- a/integration_tests/client/metrics/test_classification.py
+++ b/integration_tests/client/metrics/test_classification.py
@@ -783,11 +783,9 @@ def test_evaluate_classification_with_label_maps(
     model.finalize_inferences(dataset)
 
     # check baseline case, where we have mismatched ground truth and prediction label keys
-    result = model.evaluate_classification(dataset).wait_for_completion(
-        timeout=30
-    )
-
-    assert result.value == "failed"
+    with pytest.raises(ClientException) as e:
+        model.evaluate_classification(dataset)
+    assert "label keys must match" in str(e)
 
     # now try using a label map to connect all the cats
 
@@ -1173,8 +1171,6 @@ def test_evaluate_classification_mismatched_label_keys(
 
     model.finalize_inferences(dataset)
 
-    result = model.evaluate_classification(dataset).wait_for_completion(
-        timeout=30
-    )
-
-    assert result.value == "failed"
+    with pytest.raises(ClientException) as e:
+        model.evaluate_classification(dataset)
+    assert "label keys must match" in str(e)


### PR DESCRIPTION
### Problem Description

Validation for classification tasks is silently failing when there is a label mismatch.

### Feature Description

Move validation outside of the computation.