### PR TITLE
raster alignment migration

### DIFF
--- a/migrations/sql/00000005_realign_rasters.up.sql
+++ b/migrations/sql/00000005_realign_rasters.up.sql
@@ -1,1 +1,1 @@
-UPDATE annotation SET raster = ST_SetUpperLeft(raster, 0, 0);
+UPDATE annotation SET raster = ST_SetUpperLeft(raster, 0, 0) WHERE raster IS NOT NULL;

--- a/migrations/sql/00000005_realign_rasters.up.sql
+++ b/migrations/sql/00000005_realign_rasters.up.sql
@@ -1,0 +1,1 @@
+UPDATE annotation SET raster = ST_SetUpperLeft(raster, 0, 0);


### PR DESCRIPTION
### Reproducible Example

```python
valor=# SELECT ST_METADATA(raster), created_at from annotation
                             st_metadata                              |         created_at         
----------------------------------------------------------------------+----------------------------
 (7.125735282897949e-05,-1.4152377843856812e-05,650,650,1,1,0,0,0,1)  | 2024-04-17 12:34:51.598601
```


### Issue Description

[PR #525](https://github.com/Striveworks/valor/pull/525) is missing a migration.

### Expected Behavior

All rasters originating from geometries should be aligned to an upper left point of (0,0)


### Example

```
""" Valor v0.16.0 """

import numpy as np
from valor import Dataset, GroundTruth, Datum, Annotation
from valor.schemas import Raster, BoundingBox, MultiPolygon, Polygon, BasicPolygon, Point
ds = Dataset.create('myDataset')
ds.add_groundtruth(
    groundtruth=GroundTruth(
        datum=Datum(uid="uuid123", metadata={"height": 150, "width": 150}),
        annotations=[
            Annotation(
                task_type=TaskType.SEMANTIC_SEGMENTATION,
                labels=[Label(key="k1", value="v1")],
                raster=Raster.from_numpy(np.random.random((150,150)) > 0.5)
            ),
            Annotation(
                task_type=TaskType.SEMANTIC_SEGMENTATION,
                labels=[Label(key="k1", value="v4")],
                multipolygon=MultiPolygon(
                    polygons=[
                        Polygon(
                            boundary=BasicPolygon(
                                points=[
                                    Point(x=10.13215451414, y=0.12323425235), 
                                    Point(x=1.514135414, y=4.15424525), 
                                    Point(x=111.52435623, y=3.5534554), 
                                ]
                            ),
                            holes=[
                                BasicPolygon(
                                    points=[
                                        Point(x=10.13215451414, y=0.12323425235),
                                        Point(x=4.514135414, y=4.15424525), 
                                        Point(x=40.52435623, y=3.5534554), 
                                    ]
                                )
                            ]
                        )
                    ]
                )
            )
        ]
    )
)
```

Results in the following:

```
valor=# select st_metadata(raster) from annotation;
                     st_metadata                     
-----------------------------------------------------
 (0,0,150,150,1,1,0,0,0,1)
 (1.514135414,0.15424524999999978,110,4,1,1,0,0,0,1)
(2 rows)
```

Applying the migration results in 

```
valor=# UPDATE annotation SET raster = ST_SetUpperLeft(raster, 0, 0) WHERE raster IS NOT NULL;
UPDATE 2
valor=# select st_metadata(raster) from annotation;
        st_metadata        
---------------------------
 (0,0,150,150,1,1,0,0,0,1)
 (0,0,110,4,1,1,0,0,0,1)
(2 rows)
```