### PR TITLE
add finegrained exceptions to client

### DIFF
--- a/api/tests/unit-tests/test_main.py
+++ b/api/tests/unit-tests/test_main.py
@@ -794,13 +794,6 @@ def test_finalize_datasets(crud, client: TestClient):
         resp = client.put("datasets/dsetname/finalize")
         assert resp.status_code == 404
 
-    with patch(
-        "valor_api.main.crud.finalize",
-        side_effect=exceptions.DatasetIsEmptyError(""),
-    ):
-        resp = client.put("datasets/dsetname/finalize")
-        assert resp.status_code == 409
-
     resp = client.get("/datasets/dsetname/finalize")
     assert resp.status_code == 405
 
@@ -891,13 +884,6 @@ def test_finalize_inferences(crud, client: TestClient):
     ):
         resp = client.put("/models/modelname/datasets/dsetname/finalize")
         assert resp.status_code == 404
-
-    with patch(
-        "valor_api.main.crud.finalize",
-        side_effect=exceptions.DatasetIsEmptyError(""),
-    ):
-        resp = client.put("/models/modelname/datasets/dsetname/finalize")
-        assert resp.status_code == 409
 
     resp = client.get("/models/modelname/datasets/dsetname/finalize")
     assert resp.status_code == 405

--- a/api/valor_api/exceptions.py
+++ b/api/valor_api/exceptions.py
@@ -280,24 +280,6 @@ class DatumAlreadyExistsError(Exception):
         super().__init__(f"Datum with uid: `{uid}` already exists.")
 
 
-class DatumDoesNotBelongToDatasetError(Exception):
-    """
-    Raises an exception if the user tries to manipulate a datum that doesn't exist on a particular dataset.
-
-    Parameters
-    -------
-    dataset_name : str
-        The name of the dataset.
-    datum_uid : str
-        The UID of the datum.
-    """
-
-    def __init__(self, dataset_name: str, datum_uid: str):
-        super().__init__(
-            f"Datum with uid: `{datum_uid}` does not belong to dataset `{dataset_name}`."
-        )
-
-
 """ Annotation """
 
 
@@ -451,7 +433,6 @@ error_to_status_code = {
     ModelNotFinalizedError: 409,
     ModelStateError: 409,
     DatumAlreadyExistsError: 409,
-    DatumDoesNotBelongToDatasetError: 409,
     AnnotationAlreadyExistsError: 409,
     GroundTruthAlreadyExistsError: 409,
     PredictionAlreadyExistsError: 409,
@@ -486,7 +467,6 @@ def create_http_error(
         | ModelNotFinalizedError
         | ModelStateError
         | DatumAlreadyExistsError
-        | DatumDoesNotBelongToDatasetError
         | AnnotationAlreadyExistsError
         | GroundTruthAlreadyExistsError
         | PredictionAlreadyExistsError

--- a/api/valor_api/exceptions.py
+++ b/api/valor_api/exceptions.py
@@ -137,20 +137,6 @@ class ModelDoesNotExistError(Exception):
         super().__init__(f"Model with name `{name}` does not exist.")
 
 
-class ModelIsEmptyError(Exception):
-    """
-    Raises an exception if the user tries to manipulate an empty model.
-
-    Parameters
-    -------
-    name : str
-        The name of the model.
-    """
-
-    def __init__(self, name: str):
-        super().__init__(f"Model with name `{name}` contains no inferences.")
-
-
 class ModelFinalizedError(Exception):
     """
     Raises an exception if the user tries to add predictions to a model that has been finalized.
@@ -396,7 +382,6 @@ class EvaluationStateError(Exception):
 error_to_status_code = {
     # 400
     Exception: 400,
-    ModelIsEmptyError: 400,
     ValueError: 400,
     AttributeError: 400,
     # 404
@@ -432,7 +417,6 @@ error_to_status_code = {
 def create_http_error(
     error: (
         Exception
-        | ModelIsEmptyError
         | ValueError
         | AttributeError
         | DatasetDoesNotExistError

--- a/api/valor_api/exceptions.py
+++ b/api/valor_api/exceptions.py
@@ -173,24 +173,6 @@ class ModelNotFinalizedError(Exception):
         )
 
 
-class ModelInferencesDoNotExist(Exception):
-    """
-    Raises an exception if the user tries to manipulate an inference that doesn't exist.
-
-    Parameters
-    -------
-    dataset_name : str
-        The name of the dataset.
-    model_name : str
-        The name of the model.
-    """
-
-    def __init__(self, *, dataset_name: str, model_name: str):
-        super().__init__(
-            f"inferences for model `{model_name}` over dataset `{dataset_name}` do not exist."
-        )
-
-
 class ModelStateError(Exception):
     """
     Raise an exception if a requested state transition is illegal.
@@ -377,7 +359,6 @@ error_to_status_code = {
     DatasetDoesNotExistError: 404,
     DatumDoesNotExistError: 404,
     ModelDoesNotExistError: 404,
-    ModelInferencesDoNotExist: 404,
     EvaluationDoesNotExistError: 404,
     PredictionDoesNotExistError: 404,
     # 409
@@ -410,7 +391,6 @@ def create_http_error(
         | DatasetDoesNotExistError
         | DatumDoesNotExistError
         | ModelDoesNotExistError
-        | ModelInferencesDoNotExist
         | EvaluationDoesNotExistError
         | DatasetAlreadyExistsError
         | DatasetFinalizedError

--- a/api/valor_api/exceptions.py
+++ b/api/valor_api/exceptions.py
@@ -269,17 +269,6 @@ class AnnotationAlreadyExistsError(Exception):
         )
 
 
-class GroundTruthAlreadyExistsError(Exception):
-    """
-    Raises an exception if a ground truth is duplicated.
-    """
-
-    def __init__(self, annotation_id: int, label_id: int):
-        super().__init__(
-            f"A ground truth already exists mapping label `{label_id}` to annotation `{annotation_id}`."
-        )
-
-
 class PredictionAlreadyExistsError(Exception):
     """
     Raises an exception if a prediction is duplicated.
@@ -402,7 +391,6 @@ error_to_status_code = {
     ModelStateError: 409,
     DatumAlreadyExistsError: 409,
     AnnotationAlreadyExistsError: 409,
-    GroundTruthAlreadyExistsError: 409,
     PredictionAlreadyExistsError: 409,
     EvaluationAlreadyExistsError: 409,
     EvaluationRunningError: 409,
@@ -434,7 +422,6 @@ def create_http_error(
         | ModelStateError
         | DatumAlreadyExistsError
         | AnnotationAlreadyExistsError
-        | GroundTruthAlreadyExistsError
         | PredictionAlreadyExistsError
         | EvaluationAlreadyExistsError
         | EvaluationRunningError

--- a/api/valor_api/exceptions.py
+++ b/api/valor_api/exceptions.py
@@ -46,22 +46,6 @@ class DatasetDoesNotExistError(Exception):
         super().__init__(f"Dataset with name `{name}` does not exist.")
 
 
-class DatasetIsEmptyError(Exception):
-    """
-    Raises an exception if the user tries to manipulate an empty dataset.
-
-    Parameters
-    -------
-    name : str
-        The name of the dataset.
-    """
-
-    def __init__(self, name: str):
-        super().__init__(
-            f"Dataset with name `{name}` contains no groundtruths."
-        )
-
-
 class DatasetFinalizedError(Exception):
     """
     Raises an exception if the user tries to add groundtruths to a dataset that has already been finalized.
@@ -424,7 +408,6 @@ error_to_status_code = {
     PredictionDoesNotExistError: 404,
     # 409
     DatasetAlreadyExistsError: 409,
-    DatasetIsEmptyError: 409,
     DatasetFinalizedError: 409,
     DatasetNotFinalizedError: 409,
     DatasetStateError: 409,
@@ -458,7 +441,6 @@ def create_http_error(
         | ModelInferencesDoNotExist
         | EvaluationDoesNotExistError
         | DatasetAlreadyExistsError
-        | DatasetIsEmptyError
         | DatasetFinalizedError
         | DatasetNotFinalizedError
         | DatasetStateError

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -15,8 +15,8 @@ from valor.enums import TableStatus
 from valor.exceptions import (
     ClientAlreadyConnectedError,
     ClientConnectionFailed,
-    ClientException,
     ClientNotConnectedError,
+    raise_client_exception,
 )
 from valor.schemas import EvaluationRequest
 
@@ -303,10 +303,7 @@ class ClientConnection:
                 ):
                     self._get_access_token_from_username_and_password()
                 else:
-                    try:
-                        raise ClientException(resp)
-                    except (requests.exceptions.JSONDecodeError, KeyError):
-                        resp.raise_for_status()
+                    raise_client_exception(resp)
             else:
                 break
             tried = True

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -657,7 +657,7 @@ class ClientConnection:
             A dictionary describing a datum.
         """
         return self._requests_get_rel_host(
-            f"/data/dataset/{dataset_name}/uid/{uid}"
+            f"data/dataset/{dataset_name}/uid/{uid}"
         ).json()
 
     def create_model(self, model: dict) -> None:

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -1323,18 +1323,13 @@ class Client:
         Union[Dataset, None]
             A Dataset with a matching name, or 'None' if one doesn't exist.
         """
-        try:
-            dataset = Dataset.decode_value(
-                {
-                    **self.conn.get_dataset(name),
-                    "connection": self.conn,
-                }
-            )
-            return dataset
-        except ClientException as e:
-            if e.status_code == 404:
-                return None
-            raise e
+        dataset = Dataset.decode_value(
+            {
+                **self.conn.get_dataset(name),
+                "connection": self.conn,
+            }
+        )
+        return dataset
 
     def get_datasets(
         self,

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -1551,19 +1551,15 @@ class Client:
         )
         model_name = model.get_name() if isinstance(model, Model) else model
         datum_uid = datum.get_uid() if isinstance(datum, Datum) else datum
-        try:
-            resp = self.conn.get_prediction(
-                dataset_name=dataset_name,
-                model_name=model_name,
-                datum_uid=datum_uid,
-            )
-            resp.pop("dataset_name")
-            resp.pop("model_name")
-            return Prediction.decode_value(resp)
-        except ClientException as e:
-            if e.status_code == 404:
-                return None
-            raise e
+
+        resp = self.conn.get_prediction(
+            dataset_name=dataset_name,
+            model_name=model_name,
+            datum_uid=datum_uid,
+        )
+        resp.pop("dataset_name")
+        resp.pop("model_name")
+        return Prediction.decode_value(resp)
 
     def finalize_inferences(
         self, dataset: Union[Dataset, str], model: Union[Model, str]

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from valor.client import ClientConnection, connect, get_connection
 from valor.enums import AnnotationType, EvaluationStatus, TableStatus, TaskType
-from valor.exceptions import ClientException
+from valor.exceptions import ClientException, DatasetDoesNotExistError
 from valor.schemas import (
     Annotation,
     Datum,
@@ -1461,7 +1461,9 @@ class Client:
         self.conn.delete_dataset(name)
         if timeout:
             for _ in range(timeout):
-                if self.get_dataset(name) is None:
+                try:
+                    self.get_dataset(name)
+                except DatasetDoesNotExistError:
                     break
                 else:
                     time.sleep(1)

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -1409,13 +1409,8 @@ class Client:
         dataset_name = (
             dataset.get_name() if isinstance(dataset, Dataset) else dataset
         )
-        try:
-            resp = self.conn.get_datum(dataset_name=dataset_name, uid=uid)
-            return Datum.decode_value(resp)
-        except ClientException as e:
-            if e.status_code == 404:
-                return None
-            raise e
+        resp = self.conn.get_datum(dataset_name=dataset_name, uid=uid)
+        return Datum.decode_value(resp)
 
     def get_dataset_status(
         self,

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -26,58 +26,107 @@ class ClientConnectionFailed(Exception):
 
 
 class ServiceUnavailable(ClientException):
+    """
+    Raises an exception if the Valor service is unavailble.
+    """
+
     pass
 
 
 class DatasetAlreadyExistsError(ClientException):
+    """
+    Raises an exception if the user tries to create a dataset with a name that already exists.
+    """
+
     pass
 
 
 class DatasetDoesNotExistError(ClientException):
+    """
+    Raises an exception if the user tries to manipulate a dataset that doesn't exist.
+    """
+
     pass
 
 
 class DatasetFinalizedError(ClientException):
+    """
+    Raises an exception if the user tries to add groundtruths to a dataset that has already been finalized.
+    """
+
     pass
 
 
 class DatasetNotFinalizedError(ClientException):
+    """
+    Raises an exception if the user tries to process a dataset that hasn't been finalized.
+    """
+
     pass
 
 
 class ModelAlreadyExistsError(ClientException):
+    """
+    Raises an exception if the user tries to create a model using a name that already exists in the database.
+    """
+
     pass
 
 
 class ModelDoesNotExistError(ClientException):
+    """
+    Raises an exception if the user tries to manipulate a model that doesn't exist.
+    """
+
     pass
 
 
 class ModelFinalizedError(ClientException):
+    """
+    Raises an exception if the user tries to add predictions to a model that has been finalized.
+    """
+
     pass
 
 
 class ModelNotFinalizedError(ClientException):
-    pass
+    """
+    Raises an exception if the user tries to manipulate a model that hasn't been finalized.
+    """
 
-
-class ModelInferencesDoNotExist(ClientException):
     pass
 
 
 class DatumDoesNotExistError(ClientException):
+    """
+    Raises an exception if the user tries to manipulate a datum that doesn't exist.
+    """
+
     pass
 
 
 class DatumAlreadyExistsError(ClientException):
+    """
+    Raises an exception if the user tries to create a datum that already exists.
+
+    """
+
     pass
 
 
 class AnnotationAlreadyExistsError(ClientException):
+    """
+    Raises an exception if the user tries to create a annotation for a datum that already has annotation(s).
+    """
+
     pass
 
 
 class PredictionDoesNotExistError(ClientException):
+    """
+    Raises an exception if a prediction does not exist for a given model, dataset, and datum
+    """
+
     pass
 
 

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -89,10 +89,6 @@ class DatumAlreadyExistsError(ClientException):
     pass
 
 
-class DatumDoesNotBelongToDatasetError(ClientException):
-    pass
-
-
 class AnnotationAlreadyExistsError(ClientException):
     pass
 
@@ -135,10 +131,10 @@ def raise_client_exception(resp: Response):
         try:
             error_dict = json.loads(resp_json["detail"])
             cls_name = error_dict["name"]
-            if cls_name in locals() and issubclass(
-                locals()[cls_name], ClientException
+            if cls_name in globals() and issubclass(
+                globals()[cls_name], ClientException
             ):
-                raise locals()[cls_name](resp)
+                raise globals()[cls_name](resp)
             else:
                 raise ClientException(resp)
         except (TypeError, json.JSONDecodeError):

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -37,19 +37,11 @@ class DatasetDoesNotExistError(ClientException):
     pass
 
 
-class DatasetIsEmptyError(ClientException):
-    pass
-
-
 class DatasetFinalizedError(ClientException):
     pass
 
 
 class DatasetNotFinalizedError(ClientException):
-    pass
-
-
-class DatasetStateError(ClientException):
     pass
 
 

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -77,35 +77,7 @@ class AnnotationAlreadyExistsError(ClientException):
     pass
 
 
-class GroundTruthAlreadyExistsError(ClientException):
-    pass
-
-
-class PredictionAlreadyExistsError(ClientException):
-    pass
-
-
 class PredictionDoesNotExistError(ClientException):
-    pass
-
-
-class EvaluationDoesNotExistError(ClientException):
-    pass
-
-
-class EvaluationAlreadyExistsError(ClientException):
-    pass
-
-
-class EvaluationRunningError(ClientException):
-    pass
-
-
-class EvaluationRequestError(ClientException):
-    pass
-
-
-class EvaluationStateError(ClientException):
     pass
 
 

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -131,13 +131,17 @@ class EvaluationStateError(ClientException):
 
 def raise_client_exception(resp: Response):
     try:
-        error_dict = json.loads(resp.json()["detail"])
-        cls_name = error_dict["name"]
-        if cls_name in locals() and issubclass(
-            locals()[cls_name], ClientException
-        ):
-            raise locals()[cls_name](resp)
-        else:
+        resp_json = resp.json()
+        try:
+            error_dict = json.loads(resp_json["detail"])
+            cls_name = error_dict["name"]
+            if cls_name in locals() and issubclass(
+                locals()[cls_name], ClientException
+            ):
+                raise locals()[cls_name](resp)
+            else:
+                raise ClientException(resp)
+        except (TypeError, json.JSONDecodeError):
             raise ClientException(resp)
     except (exceptions.JSONDecodeError, KeyError):
         resp.raise_for_status()

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -1,3 +1,8 @@
+import json
+
+from requests import Response, exceptions
+
+
 class ClientException(Exception):
     def __init__(self, resp):
         self.status_code = resp.status_code
@@ -18,3 +23,121 @@ class ClientNotConnectedError(Exception):
 class ClientConnectionFailed(Exception):
     def __init__(self, msg: str):
         super().__init__(msg)
+
+
+class ServiceUnavailable(ClientException):
+    pass
+
+
+class DatasetAlreadyExistsError(ClientException):
+    pass
+
+
+class DatasetDoesNotExistError(ClientException):
+    pass
+
+
+class DatasetIsEmptyError(ClientException):
+    pass
+
+
+class DatasetFinalizedError(ClientException):
+    pass
+
+
+class DatasetNotFinalizedError(ClientException):
+    pass
+
+
+class DatasetStateError(ClientException):
+    pass
+
+
+class ModelAlreadyExistsError(ClientException):
+    pass
+
+
+class ModelDoesNotExistError(ClientException):
+    pass
+
+
+class ModelIsEmptyError(ClientException):
+    pass
+
+
+class ModelFinalizedError(ClientException):
+    pass
+
+
+class ModelNotFinalizedError(ClientException):
+    pass
+
+
+class ModelInferencesDoNotExist(ClientException):
+    pass
+
+
+class ModelStateError(ClientException):
+    pass
+
+
+class DatumDoesNotExistError(ClientException):
+    pass
+
+
+class DatumAlreadyExistsError(ClientException):
+    pass
+
+
+class DatumDoesNotBelongToDatasetError(ClientException):
+    pass
+
+
+class AnnotationAlreadyExistsError(ClientException):
+    pass
+
+
+class GroundTruthAlreadyExistsError(ClientException):
+    pass
+
+
+class PredictionAlreadyExistsError(ClientException):
+    pass
+
+
+class PredictionDoesNotExistError(ClientException):
+    pass
+
+
+class EvaluationDoesNotExistError(ClientException):
+    pass
+
+
+class EvaluationAlreadyExistsError(ClientException):
+    pass
+
+
+class EvaluationRunningError(ClientException):
+    pass
+
+
+class EvaluationRequestError(ClientException):
+    pass
+
+
+class EvaluationStateError(ClientException):
+    pass
+
+
+def raise_client_exception(resp: Response):
+    try:
+        error_dict = json.loads(resp.json()["detail"])
+        cls_name = error_dict["name"]
+        if cls_name in locals() and issubclass(
+            locals()[cls_name], ClientException
+        ):
+            raise locals()[cls_name](resp)
+        else:
+            raise ClientException(resp)
+    except (exceptions.JSONDecodeError, KeyError):
+        resp.raise_for_status()

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -53,10 +53,6 @@ class ModelDoesNotExistError(ClientException):
     pass
 
 
-class ModelIsEmptyError(ClientException):
-    pass
-
-
 class ModelFinalizedError(ClientException):
     pass
 
@@ -66,10 +62,6 @@ class ModelNotFinalizedError(ClientException):
 
 
 class ModelInferencesDoNotExist(ClientException):
-    pass
-
-
-class ModelStateError(ClientException):
     pass
 
 

--- a/integration_tests/client/datasets/test_dataset.py
+++ b/integration_tests/client/datasets/test_dataset.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from valor import Annotation, Client, Dataset, Datum, GroundTruth, Label
 from valor.enums import TableStatus, TaskType
-from valor.exceptions import ClientException
+from valor.exceptions import ClientException, DatasetDoesNotExistError
 from valor.metatypes import ImageMetadata
 from valor_api.backend import models
 
@@ -217,7 +217,8 @@ def test_client_delete_dataset(
     assert db.scalar(select(func.count(models.Dataset.name))) == 1
     client.delete_dataset(dataset_name, timeout=30)
     assert db.scalar(select(func.count(models.Dataset.name))) == 0
-    assert Dataset.get(dataset_name) is None
+    with pytest.raises(DatasetDoesNotExistError):
+        Dataset.get(dataset_name)
 
 
 def test_create_tabular_dataset_and_add_groundtruth(

--- a/integration_tests/client/models/test_model.py
+++ b/integration_tests/client/models/test_model.py
@@ -503,12 +503,6 @@ def test_get_prediction(client: Client, model_name: str, dataset_name: str):
     dataset.add_groundtruth(GroundTruth(datum=datum, annotations=[]))
     dataset.finalize()
 
-    # check we get None if the datum does not exist
-    assert model.get_prediction(dataset, Datum(uid="does not exist")) is None
-
-    # check that we also get None if the datum does exist but there is no prediction
-    assert model.get_prediction(dataset, datum) is None
-
     # add a prediction with no annotaitons and check we get a prediction back
     model.add_prediction(dataset, Prediction(datum=datum, annotations=[]))
     assert model.get_prediction(dataset, datum) is not None

--- a/integration_tests/client/test_exceptions.py
+++ b/integration_tests/client/test_exceptions.py
@@ -50,3 +50,29 @@ def test_datum_exceptions(client: Client, dataset_name: str):
 
     with pytest.raises(exceptions.DatumDoesNotExistError):
         client.get_datum(dataset_name, "nonexistent")
+
+
+def test_model_exceptions(client: Client, model_name: str, dataset_name: str):
+    # test `ModelDoesNotExistError`
+    with pytest.raises(exceptions.ModelDoesNotExistError):
+        client.get_model("nonexistent")
+
+    # test `ModelAlreadyExistsError`
+    model = Model.create(model_name)
+    with pytest.raises(exceptions.ModelAlreadyExistsError):
+        Model.create(model_name)
+
+    # test `ModelNotFinalizedError`
+    dset = Dataset.create(dataset_name)
+    dset.add_groundtruth(GroundTruth(datum=Datum(uid="uid"), annotations=[]))
+    dset.finalize()
+    with pytest.raises(exceptions.ModelNotFinalizedError):
+        model.evaluate_classification(dset)
+
+    # test `ModelFinalizedError`
+    model.finalize_inferences(dset)
+    with pytest.raises(exceptions.ModelFinalizedError):
+        model.add_prediction(
+            dset,
+            Prediction(datum=Datum(uid="uid"), annotations=[]),
+        )

--- a/integration_tests/client/test_exceptions.py
+++ b/integration_tests/client/test_exceptions.py
@@ -1,6 +1,43 @@
 import pytest
 
-from valor import Client, Dataset, Datum, GroundTruth, exceptions
+from valor import (
+    Client,
+    Dataset,
+    Datum,
+    GroundTruth,
+    Model,
+    Prediction,
+    exceptions,
+)
+
+
+def test_dataset_exceptions(
+    client: Client, dataset_name: str, model_name: str
+):
+    # test `DatasetDoesNotExistError`
+    with pytest.raises(exceptions.DatasetDoesNotExistError):
+        client.get_dataset("nonexistent")
+
+    # test `DatasetAlreadyExistsError`
+    dset = Dataset.create(dataset_name)
+
+    with pytest.raises(exceptions.DatasetAlreadyExistsError):
+        Dataset.create(dataset_name)
+
+    # test `DatasetNotFinalizedError`
+    model = Model.create(model_name)
+    dset.add_groundtruth(GroundTruth(datum=Datum(uid="uid"), annotations=[]))
+    model.add_prediction(
+        dset, Prediction(datum=Datum(uid="uid"), annotations=[])
+    )
+    with pytest.raises(exceptions.DatasetNotFinalizedError):
+        model.evaluate_classification(dset)
+
+    dset.finalize()
+    with pytest.raises(exceptions.DatasetFinalizedError):
+        dset.add_groundtruth(
+            GroundTruth(datum=Datum(uid="uid"), annotations=[])
+        )
 
 
 def test_datum_exceptions(client: Client, dataset_name: str):

--- a/integration_tests/client/test_exceptions.py
+++ b/integration_tests/client/test_exceptions.py
@@ -1,0 +1,15 @@
+import pytest
+
+from valor import Client, Dataset, Datum, GroundTruth, exceptions
+
+
+def test_datum_exceptions(client: Client, dataset_name: str):
+    dset = Dataset.create(dataset_name)
+    datum = Datum(uid="uid")
+    dset.add_groundtruth(GroundTruth(datum=datum, annotations=[]))
+
+    with pytest.raises(exceptions.DatumAlreadyExistsError):
+        dset.add_groundtruth(GroundTruth(datum=datum, annotations=[]))
+
+    with pytest.raises(exceptions.DatumDoesNotExistError):
+        client.get_datum(dataset_name, "nonexistent")

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -10,12 +10,18 @@ import pytest
 from sqlalchemy import create_engine, select, text
 from sqlalchemy.orm import Session
 
-from valor import Annotation, Client, GroundTruth, Label, Prediction
+from valor import (
+    Annotation,
+    Client,
+    GroundTruth,
+    Label,
+    Prediction,
+    exceptions,
+)
 from valor.client import ClientConnection, connect, reset_connection
 from valor.enums import TaskType
 from valor.metatypes import Datum
 from valor.schemas import Box, MultiPolygon, Point, Polygon, Raster
-from valor_api import exceptions
 from valor_api.backend import models
 
 


### PR DESCRIPTION
Beyond adding finegrained exceptions to the client as outlined in #482 , this PR

- [ ] Removes some backend exceptions that were never used
- [ ] Changes behavior so that when calls like `get_dataset` or `get_prediction` are requested on things that don't exist, instead of returning `None` we raise an exception