### PR TITLE
add ignore_existing_datums argument for bulk uploads

### DIFF
--- a/api/tests/functional-tests/backend/core/test_annotation.py
+++ b/api/tests/functional-tests/backend/core/test_annotation.py
@@ -89,7 +89,7 @@ def test_create_annotation_already_exists_error(
 
     core.create_groundtruths(db, empty_groundtruths)
     core.create_predictions(db, empty_predictions)
-    with pytest.raises(exceptions.DatumsAlreadyExistsError):
+    with pytest.raises(exceptions.DatumsAlreadyExistError):
         core.create_groundtruths(db, empty_groundtruths[0:1])
     with pytest.raises(exceptions.AnnotationAlreadyExistsError):
         core.create_predictions(db, empty_predictions[0:1])

--- a/api/tests/functional-tests/backend/core/test_annotation.py
+++ b/api/tests/functional-tests/backend/core/test_annotation.py
@@ -89,7 +89,7 @@ def test_create_annotation_already_exists_error(
 
     core.create_groundtruths(db, empty_groundtruths)
     core.create_predictions(db, empty_predictions)
-    with pytest.raises(exceptions.DatumAlreadyExistsError):
+    with pytest.raises(exceptions.DatumsAlreadyExistsError):
         core.create_groundtruths(db, empty_groundtruths[0:1])
     with pytest.raises(exceptions.AnnotationAlreadyExistsError):
         core.create_predictions(db, empty_predictions[0:1])

--- a/api/tests/functional-tests/backend/core/test_datum.py
+++ b/api/tests/functional-tests/backend/core/test_datum.py
@@ -87,7 +87,7 @@ def test_create_datums(
                 ignore_existing_datums=True,
             )
         )
-        == 3
+        == 1  # only one new datum was created (uid4)
     )
 
     assert db.scalar(select(func.count()).select_from(models.Datum)) == 4

--- a/api/tests/functional-tests/backend/core/test_datum.py
+++ b/api/tests/functional-tests/backend/core/test_datum.py
@@ -92,7 +92,7 @@ def test_create_datums(
 
     assert db.scalar(select(func.count()).select_from(models.Datum)) == 4
 
-    with pytest.raises(exceptions.DatumsAlreadyExistsError) as exc_info:
+    with pytest.raises(exceptions.DatumsAlreadyExistError) as exc_info:
         core.create_datums(
             db=db,
             datums=[

--- a/api/tests/functional-tests/backend/core/test_datum.py
+++ b/api/tests/functional-tests/backend/core/test_datum.py
@@ -49,6 +49,66 @@ def test_create_datum(
     assert db.scalar(select(func.count()).select_from(models.Datum)) == 2
 
 
+def test_create_datums(
+    db: Session,
+    created_dataset: str,
+):
+    assert db.scalar(select(func.count()).select_from(models.Datum)) == 0
+    dataset = core.fetch_dataset(db=db, name=created_dataset)
+
+    assert (
+        len(
+            core.create_datums(
+                db=db,
+                datums=[
+                    schemas.Datum(uid="uid1"),
+                    schemas.Datum(uid="uid2"),
+                    schemas.Datum(uid="uid3"),
+                ],
+                datasets=[dataset] * 3,
+                ignore_existing_datums=True,
+            )
+        )
+        == 3
+    )
+
+    assert db.scalar(select(func.count()).select_from(models.Datum)) == 3
+
+    assert (
+        len(
+            core.create_datums(
+                db=db,
+                datums=[
+                    schemas.Datum(uid="uid1"),
+                    schemas.Datum(uid="uid4"),
+                    schemas.Datum(uid="uid3"),
+                ],
+                datasets=[dataset] * 3,
+                ignore_existing_datums=True,
+            )
+        )
+        == 3
+    )
+
+    assert db.scalar(select(func.count()).select_from(models.Datum)) == 4
+
+    with pytest.raises(exceptions.DatumsAlreadyExistsError) as exc_info:
+        core.create_datums(
+            db=db,
+            datums=[
+                schemas.Datum(uid="uid2"),
+                schemas.Datum(uid="uid3"),
+                schemas.Datum(uid="uid7"),
+            ],
+            datasets=[dataset] * 3,
+            ignore_existing_datums=False,
+        )
+    assert "Datums with uids" in str(exc_info.value)
+    assert "uid2" in str(exc_info.value)
+    assert "uid3" in str(exc_info.value)
+    assert "uid7" not in str(exc_info.value)
+
+
 def test_get_paginated_datums(
     db: Session,
     created_dataset: str,

--- a/api/valor_api/backend/core/datum.py
+++ b/api/valor_api/backend/core/datum.py
@@ -93,7 +93,7 @@ def create_datums(
             except exceptions.DatumDoesNotExistError:
                 pass
 
-        raise exceptions.DatumsAlreadyExistsError(
+        raise exceptions.DatumsAlreadyExistError(
             [datum.uid for datum in existing_datums]
         )
 

--- a/api/valor_api/backend/core/groundtruth.py
+++ b/api/valor_api/backend/core/groundtruth.py
@@ -9,7 +9,7 @@ from valor_api.backend import core, models
 def create_groundtruths(
     db: Session,
     groundtruths: list[schemas.GroundTruth],
-    ignore_existing_datums: bool,
+    ignore_existing_datums: bool = False,
 ):
     """Create ground truths in bulk.
 

--- a/api/valor_api/backend/core/groundtruth.py
+++ b/api/valor_api/backend/core/groundtruth.py
@@ -19,6 +19,10 @@ def create_groundtruths(
         The database Session to query against.
     groundtruths
         The ground truths to create.
+    ignore_existing_datums
+        If True, will ignore datums that already exist in the database.
+        If False, will raise an error if any datums already exist.
+        Default is False.
 
     Returns
     -------

--- a/api/valor_api/backend/core/groundtruth.py
+++ b/api/valor_api/backend/core/groundtruth.py
@@ -6,7 +6,11 @@ from valor_api import enums, exceptions, schemas
 from valor_api.backend import core, models
 
 
-def create_groundtruths(db: Session, groundtruths: list[schemas.GroundTruth]):
+def create_groundtruths(
+    db: Session,
+    groundtruths: list[schemas.GroundTruth],
+    ignore_existing_datums: bool,
+):
     """Create ground truths in bulk.
 
     Parameters
@@ -39,6 +43,7 @@ def create_groundtruths(db: Session, groundtruths: list[schemas.GroundTruth]):
             dataset_name_to_dataset[groundtruth.dataset_name]
             for groundtruth in groundtruths
         ],
+        ignore_existing_datums=ignore_existing_datums,
     )
     all_labels = [
         label

--- a/api/valor_api/backend/core/groundtruth.py
+++ b/api/valor_api/backend/core/groundtruth.py
@@ -49,6 +49,16 @@ def create_groundtruths(
         ],
         ignore_existing_datums=ignore_existing_datums,
     )
+
+    if ignore_existing_datums:
+        # datums only contains the newly created ones, so we need to filter out
+        # the ones that already existed
+        groundtruths = [
+            gt
+            for gt in groundtruths
+            if gt.datum.uid in [datum.uid for datum in datums]
+        ]
+
     all_labels = [
         label
         for groundtruth in groundtruths

--- a/api/valor_api/crud/_create.py
+++ b/api/valor_api/crud/_create.py
@@ -54,6 +54,7 @@ def create_groundtruths(
     *,
     db: Session,
     groundtruths: list[schemas.GroundTruth],
+    ignore_existing_datums: bool,
 ):
     """
     Creates a ground truth.
@@ -65,7 +66,11 @@ def create_groundtruths(
     groundtruth: schemas.GroundTruth
         The ground truth to create.
     """
-    backend.create_groundtruths(db, groundtruths=groundtruths)
+    backend.create_groundtruths(
+        db,
+        groundtruths=groundtruths,
+        ignore_existing_datums=ignore_existing_datums,
+    )
 
 
 def create_predictions(

--- a/api/valor_api/crud/_create.py
+++ b/api/valor_api/crud/_create.py
@@ -54,7 +54,7 @@ def create_groundtruths(
     *,
     db: Session,
     groundtruths: list[schemas.GroundTruth],
-    ignore_existing_datums: bool,
+    ignore_existing_datums: bool = False,
 ):
     """
     Creates a ground truth.

--- a/api/valor_api/exceptions.py
+++ b/api/valor_api/exceptions.py
@@ -232,7 +232,7 @@ class DatumAlreadyExistsError(Exception):
         super().__init__(f"Datum with uid: `{uid}` already exists.")
 
 
-class DatumsAlreadyExistsError(Exception):
+class DatumsAlreadyExistError(Exception):
     """
     Raises an exception if the user tries to create a datum that already exists.
 

--- a/api/valor_api/exceptions.py
+++ b/api/valor_api/exceptions.py
@@ -232,6 +232,20 @@ class DatumAlreadyExistsError(Exception):
         super().__init__(f"Datum with uid: `{uid}` already exists.")
 
 
+class DatumsAlreadyExistsError(Exception):
+    """
+    Raises an exception if the user tries to create a datum that already exists.
+
+    Parameters
+    -------
+    uids
+        The UIDs of the datums.
+    """
+
+    def __init__(self, uids: list[str]):
+        super().__init__(f"Datums with uids: `{uids}` already exist.")
+
+
 """ Annotation """
 
 

--- a/api/valor_api/main.py
+++ b/api/valor_api/main.py
@@ -78,6 +78,8 @@ def create_groundtruths(
         The ground truths to add to the database.
     db : Session
         The database session to use. This parameter is a sqlalchemy dependency and shouldn't be submitted by the user.
+    ignore_existing_datums : bool, optional
+        If True, will ignore datums that already exist in the database.
 
     Raises
     ------

--- a/api/valor_api/main.py
+++ b/api/valor_api/main.py
@@ -63,7 +63,9 @@ def get_db():
     tags=["GroundTruths"],
 )
 def create_groundtruths(
-    groundtruths: list[schemas.GroundTruth], db: Session = Depends(get_db)
+    groundtruths: list[schemas.GroundTruth],
+    ignore_existing_datums: bool = False,
+    db: Session = Depends(get_db),
 ):
     """
     Create a ground truth in the database.
@@ -85,7 +87,11 @@ def create_groundtruths(
         If the dataset has been finalized, or if the datum already exists.
     """
     try:
-        crud.create_groundtruths(db=db, groundtruths=groundtruths)
+        crud.create_groundtruths(
+            db=db,
+            groundtruths=groundtruths,
+            ignore_existing_datums=ignore_existing_datums,
+        )
     except Exception as e:
         raise exceptions.create_http_error(e)
 

--- a/client/unit-tests/test_client.py
+++ b/client/unit-tests/test_client.py
@@ -2,34 +2,12 @@ from unittest.mock import patch
 
 import pytest
 
-from valor.client import _chunk_list, connect, get_connection, reset_connection
+from valor.client import connect, get_connection, reset_connection
 from valor.exceptions import (
     ClientAlreadyConnectedError,
     ClientConnectionFailed,
     ClientNotConnectedError,
 )
-
-
-def test__chunk_list():
-    # edge case
-    data = [{"key": "value"}]
-    results = _chunk_list(json_list=data, chunk_size_bytes=10)
-
-    assert results == [data]
-
-    # 100 elements with an average element size of 23.8
-    data = [{f"key_{i}": f"value_{i}"} for i in range(100)]
-
-    # standard case
-    results = _chunk_list(json_list=data, chunk_size_bytes=1000)
-    assert (
-        len(results) == 4
-    )  # recursively chunked once, which added an extra split
-    assert [len(x) for x in results] == [42, 41, 1, 16]
-
-    # edge case with small chunk size
-    results = _chunk_list(json_list=data, chunk_size_bytes=1)
-    assert results == [[x] for x in data]
 
 
 @patch("valor.client.ClientConnection")

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -293,6 +293,10 @@ class ClientConnection:
         ----------
         groundtruths : List[dict]
             The ground truths to be created.
+        ignore_existing_datums : bool, default=False
+            If True, will ignore datums that already exist in the backend.
+            If False, will raise an error if any datums already exist.
+            Default is False.
         """
         self._requests_post_rel_host(
             "groundtruths",

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -527,6 +527,10 @@ class Dataset(StaticCollection):
         ----------
         groundtruths : List[GroundTruth]
             The ground truths to create.
+        ignore_existing_datums : bool, default=False
+            If True, will ignore datums that already exist in the backend.
+            If False, will raise an error if any datums already exist.
+            Default is False.
         """
         Client(self.conn).create_groundtruths(
             dataset=self,
@@ -1260,6 +1264,10 @@ class Client:
             The dataset to create the ground truth for.
         groundtruths : List[valor.GroundTruth]
             The ground truths to create.
+        ignore_existing_datums : bool, default=False
+            If True, will ignore datums that already exist in the backend.
+            If False, will raise an error if any datums already exist.
+            Default is False.
         """
         groundtruths_json = []
         for groundtruth in groundtruths:

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -518,6 +518,7 @@ class Dataset(StaticCollection):
     def add_groundtruths(
         self,
         groundtruths: List[GroundTruth],
+        ignore_existing_datums: bool = False,
     ) -> None:
         """
         Add multiple ground truths to the dataset.
@@ -530,6 +531,7 @@ class Dataset(StaticCollection):
         Client(self.conn).create_groundtruths(
             dataset=self,
             groundtruths=groundtruths,
+            ignore_existing_datums=ignore_existing_datums,
         )
 
     def get_groundtruth(
@@ -1246,6 +1248,7 @@ class Client:
         self,
         dataset: Dataset,
         groundtruths: List[GroundTruth],
+        ignore_existing_datums: bool = False,
     ):
         """
         Creates ground truths.
@@ -1269,7 +1272,9 @@ class Client:
             groundtruth_dict = groundtruth.encode_value()
             groundtruth_dict["dataset_name"] = dataset.name
             groundtruths_json.append(groundtruth_dict)
-        self.conn.create_groundtruths(groundtruths_json)
+        self.conn.create_groundtruths(
+            groundtruths_json, ignore_existing_datums=ignore_existing_datums
+        )
 
     def get_groundtruth(
         self,

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -114,6 +114,15 @@ class DatumAlreadyExistsError(ClientException):
     pass
 
 
+class DatumsAlreadyExistsError(ClientException):
+    """
+    Raises an exception if the user tries to create a datum that already exists.
+
+    """
+
+    pass
+
+
 class AnnotationAlreadyExistsError(ClientException):
     """
     Raises an exception if the user tries to create a annotation for a datum that already has annotation(s).

--- a/client/valor/exceptions.py
+++ b/client/valor/exceptions.py
@@ -114,7 +114,7 @@ class DatumAlreadyExistsError(ClientException):
     pass
 
 
-class DatumsAlreadyExistsError(ClientException):
+class DatumsAlreadyExistError(ClientException):
     """
     Raises an exception if the user tries to create a datum that already exists.
 

--- a/integration_tests/client/datasets/test_dataset.py
+++ b/integration_tests/client/datasets/test_dataset.py
@@ -437,7 +437,15 @@ def test_add_groundtruths(client: Client, dataset_name: str):
 
     dataset.add_groundtruths(
         [
-            GroundTruth(datum=Datum(uid="uid1"), annotations=[]),
+            GroundTruth(
+                datum=Datum(uid="uid1"),
+                annotations=[
+                    Annotation(
+                        task_type=TaskType.CLASSIFICATION,
+                        labels=[Label(key="k1", value="v1")],
+                    )
+                ],
+            ),
             GroundTruth(datum=Datum(uid="uid2"), annotations=[]),
         ]
     )
@@ -447,7 +455,10 @@ def test_add_groundtruths(client: Client, dataset_name: str):
         dataset.add_groundtruths(
             [
                 GroundTruth(datum=Datum(uid="uid3"), annotations=[]),
-                GroundTruth(datum=Datum(uid="uid1"), annotations=[]),
+                GroundTruth(
+                    datum=Datum(uid="uid1"),
+                    annotations=[],
+                ),
             ]
         )
 
@@ -456,9 +467,25 @@ def test_add_groundtruths(client: Client, dataset_name: str):
     dataset.add_groundtruths(
         [
             GroundTruth(datum=Datum(uid="uid3"), annotations=[]),
-            GroundTruth(datum=Datum(uid="uid1"), annotations=[]),
+            GroundTruth(
+                datum=Datum(uid="uid1"),
+                annotations=[
+                    Annotation(
+                        task_type=TaskType.CLASSIFICATION,
+                        labels=[Label(key="k2", value="v2")],
+                    )
+                ],
+            ),
         ],
         ignore_existing_datums=True,
     )
 
     assert len(dataset.get_datums()) == 3
+
+    # check that no new annotations were added to uid1, and it still
+    # has the original label
+    gt = dataset.get_groundtruth("uid1")
+    assert len(gt.annotations) == 1
+    assert len(gt.annotations[0].labels) == 1
+    assert gt.annotations[0].labels[0].key == "k1"
+    assert gt.annotations[0].labels[0].value == "v1"

--- a/integration_tests/client/datasets/test_dataset.py
+++ b/integration_tests/client/datasets/test_dataset.py
@@ -13,7 +13,7 @@ from valor.enums import TableStatus, TaskType
 from valor.exceptions import (
     ClientException,
     DatasetDoesNotExistError,
-    DatumsAlreadyExistsError,
+    DatumsAlreadyExistError,
 )
 from valor.metatypes import ImageMetadata
 from valor_api.backend import models
@@ -443,7 +443,7 @@ def test_add_groundtruths(client: Client, dataset_name: str):
     )
     assert len(dataset.get_datums()) == 2
 
-    with pytest.raises(DatumsAlreadyExistsError):
+    with pytest.raises(DatumsAlreadyExistError):
         dataset.add_groundtruths(
             [
                 GroundTruth(datum=Datum(uid="uid3"), annotations=[]),

--- a/integration_tests/client/test_exceptions.py
+++ b/integration_tests/client/test_exceptions.py
@@ -48,7 +48,7 @@ def test_datum_exceptions(client: Client, dataset_name: str):
     datum = Datum(uid="uid")
     dset.add_groundtruth(GroundTruth(datum=datum, annotations=[]))
 
-    with pytest.raises(exceptions.DatumAlreadyExistsError):
+    with pytest.raises(exceptions.DatumsAlreadyExistsError):
         dset.add_groundtruth(GroundTruth(datum=datum, annotations=[]))
 
     with pytest.raises(exceptions.DatumDoesNotExistError):

--- a/integration_tests/client/test_exceptions.py
+++ b/integration_tests/client/test_exceptions.py
@@ -48,7 +48,7 @@ def test_datum_exceptions(client: Client, dataset_name: str):
     datum = Datum(uid="uid")
     dset.add_groundtruth(GroundTruth(datum=datum, annotations=[]))
 
-    with pytest.raises(exceptions.DatumsAlreadyExistsError):
+    with pytest.raises(exceptions.DatumsAlreadyExistError):
         dset.add_groundtruth(GroundTruth(datum=datum, annotations=[]))
 
     with pytest.raises(exceptions.DatumDoesNotExistError):


### PR DESCRIPTION
This PR addresses #564 by

1. Allowing the user to pass an option to ignore existing datums when adding groundtruth
2. Get rid of the chunking strategy (put this on the onus of the user) since it can end up in a confusing state where only some groundtruths were added if there was an error in one of the chunks.