### PR TITLE
Datasets deletion bug

### DIFF
--- a/api/tests/functional-tests/backend/core/test_dataset.py
+++ b/api/tests/functional-tests/backend/core/test_dataset.py
@@ -120,15 +120,15 @@ def test_dataset_status(db: Session, created_dataset):
         == enums.TableStatus.DELETING
     )
 
-    # test others
-    with pytest.raises(exceptions.DatasetStateError):
-        core.set_dataset_status(
-            db, created_dataset, enums.TableStatus.CREATING
-        )
-    with pytest.raises(exceptions.DatasetStateError):
-        core.set_dataset_status(
-            db, created_dataset, enums.TableStatus.FINALIZED
-        )
+    # show that the dataset is unfetchable now that it has been marked for deletion
+    with pytest.raises(exceptions.DatasetDoesNotExistError):
+        core.fetch_dataset(db=db, name=created_dataset)
+
+    # show that the status is still retrievable
+    assert (
+        core.get_dataset_status(db, created_dataset)
+        == enums.TableStatus.DELETING
+    )
 
 
 def test_dataset_status_create_to_delete(db: Session, created_dataset):

--- a/api/valor_api/backend/core/dataset.py
+++ b/api/valor_api/backend/core/dataset.py
@@ -464,8 +464,8 @@ def delete_dataset(
     name : str
         The name of the dataset.
     """
-    set_dataset_status(db, name, enums.TableStatus.DELETING)
     dataset = fetch_dataset(db, name=name)
+    set_dataset_status(db, name, enums.TableStatus.DELETING)
 
     core.delete_evaluations(db=db, dataset_names=[name])
     core.delete_dataset_predictions(db, dataset)

--- a/api/valor_api/backend/core/dataset.py
+++ b/api/valor_api/backend/core/dataset.py
@@ -191,7 +191,12 @@ def get_paginated_datasets(
 
     datasets = (
         db.query(models.Dataset)
-        .where(models.Dataset.id == datasets_subquery.c.id)
+        .where(
+            and_(
+                models.Dataset.id == datasets_subquery.c.id,
+                models.Dataset.status != enums.TableStatus.DELETING,
+            )
+        )
         .order_by(desc(models.Dataset.created_at))
         .offset(offset)
         .limit(limit)
@@ -295,7 +300,12 @@ def get_n_datums_in_dataset(db: Session, name: str) -> int:
     return (
         db.query(models.Datum)
         .join(models.Dataset)
-        .where(models.Dataset.name == name)
+        .where(
+            and_(
+                models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
+            )
+        )
         .count()
     )
 
@@ -307,7 +317,12 @@ def get_n_groundtruth_annotations(db: Session, name: str) -> int:
         .join(models.GroundTruth)
         .join(models.Datum)
         .join(models.Dataset)
-        .where(models.Dataset.name == name)
+        .where(
+            and_(
+                models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
+            )
+        )
         .count()
     )
 
@@ -321,6 +336,7 @@ def get_n_groundtruth_bounding_boxes_in_dataset(db: Session, name: str) -> int:
         .where(
             and_(
                 models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
                 models.Annotation.box.isnot(None),
             )
         )
@@ -338,6 +354,7 @@ def get_n_groundtruth_polygons_in_dataset(db: Session, name: str) -> int:
         .where(
             and_(
                 models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
                 models.Annotation.polygon.isnot(None),
             )
         )
@@ -355,6 +372,7 @@ def get_n_groundtruth_rasters_in_dataset(db: Session, name: str) -> int:
         .where(
             and_(
                 models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
                 models.Annotation.raster.isnot(None),
             )
         )
@@ -385,7 +403,12 @@ def get_unique_task_types_in_dataset(
         .select_from(models.Annotation)
         .join(models.Datum, models.Datum.id == models.Annotation.datum_id)
         .join(models.Dataset, models.Dataset.id == models.Datum.dataset_id)
-        .where(models.Dataset.name == name)
+        .where(
+            and_(
+                models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
+            )
+        )
         .distinct()
         .all()
     )
@@ -400,7 +423,12 @@ def get_unique_datum_metadata_in_dataset(
     md = db.scalars(
         select(models.Datum.meta)
         .join(models.Dataset)
-        .where(models.Dataset.name == name)
+        .where(
+            and_(
+                models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
+            )
+        )
         .distinct()
     ).all()
 
@@ -417,7 +445,12 @@ def get_unique_groundtruth_annotation_metadata_in_dataset(
         .join(models.GroundTruth)
         .join(models.Datum)
         .join(models.Dataset)
-        .where(models.Dataset.name == name)
+        .where(
+            and_(
+                models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
+            )
+        )
         .distinct()
     ).all()
 

--- a/api/valor_api/backend/core/dataset.py
+++ b/api/valor_api/backend/core/dataset.py
@@ -101,8 +101,8 @@ def fetch_dataset(
         db.query(models.Dataset)
         .where(
             and_(
-                models.Dataset.name == name  # type: ignore https://github.com/microsoft/pyright/issues/5062
-                and models.Dataset.status != enums.TableStatus.DELETING  # type: ignore nhttps://github.com/microsoft/pyright/issues/5062
+                models.Dataset.name == name,
+                models.Dataset.status != enums.TableStatus.DELETING,
             )
         )
         .one_or_none()
@@ -230,7 +230,13 @@ def get_dataset_status(
     enums.TableStatus
         The status of the dataset.
     """
-    dataset = fetch_dataset(db, name)
+    dataset = (
+        db.query(models.Dataset)
+        .where(models.Dataset.name == name)
+        .one_or_none()
+    )
+    if dataset is None:
+        raise exceptions.DatasetDoesNotExistError(name)
     return enums.TableStatus(dataset.status)
 
 


### PR DESCRIPTION
### Solution

Once marked for deletion, evaluations should not be able to access the dataset.

We can implement a custom fetch call for the `get_dataset_status` function to make sure that an in progress deletion status can be observed.

### Reproducible Example

When a dataset is marked for deletion (e.g. `dataset.delete()`) it is still accessible to the user for evaluation.

This is displayed by the existing test [here](https://github.com/Striveworks/valor/blob/de8fe7562ee3ad5eccb1ae10195f71d94c3156eb/api/tests/functional-tests/backend/core/test_dataset.py#L116-L121) where a dataset is marked for deletion and then still accessible by the `get_status` function.

### Issue Description

This behavior of still being able to retrieve the status of a dataset in the midst of deletion seems okay at face value. However, when we look at the `fetch_dataset` function we can see that this is caused by a malformed sqlalchemy query that has been masked by a type ignore.

```
dataset = (
        db.query(models.Dataset)
        .where(
            and_(
                models.Dataset.name == name  # type: ignore https://github.com/microsoft/pyright/issues/5062
                and models.Dataset.status != enums.TableStatus.DELETING  # type: ignore nhttps://github.com/microsoft/pyright/issues/5062
            )
        )
        .one_or_none()
    )
```

The corrected function looks like this.

```
dataset = (
    db.query(models.Dataset)
    .where(
        and_(
            models.Dataset.name == name,
            models.Dataset.status != enums.TableStatus.DELETING,
        )
    )
    .one_or_none()
)
```
