### PR TITLE
Removed `meta` from `schemas.EvaluationRequest`

### DIFF
--- a/api/tests/functional-tests/backend/core/test_dataset.py
+++ b/api/tests/functional-tests/backend/core/test_dataset.py
@@ -161,7 +161,6 @@ def test_dataset_status_with_evaluations(
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION,
             ),
-            meta={},
         ),
     )
     assert len(evaluations) == 1

--- a/api/tests/functional-tests/backend/core/test_evaluation.py
+++ b/api/tests/functional-tests/backend/core/test_evaluation.py
@@ -190,7 +190,6 @@ def test__fetch_evaluation_from_subrequest(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
     created_1 = core.create_or_get_evaluations(db, job_request_1)
     assert len(created_1) == 1
@@ -202,7 +201,6 @@ def test__fetch_evaluation_from_subrequest(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.SEMANTIC_SEGMENTATION,
         ),
-        meta={},
     )
     created_2 = core.create_or_get_evaluations(db, job_request_2)
     assert len(created_2) == 1
@@ -216,7 +214,6 @@ def test__fetch_evaluation_from_subrequest(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
     existing = _fetch_evaluation_from_subrequest(
         db=db,
@@ -250,7 +247,6 @@ def test_create_evaluation(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
     created = core.create_or_get_evaluations(db, job_request_1)
     assert len(created) == 1
@@ -298,7 +294,6 @@ def test_create_evaluation(
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION,
             ),
-            meta={},
         )
         core.create_or_get_evaluations(db, job_request_1)
     assert "No datasets" in str(e)
@@ -309,7 +304,6 @@ def test_create_evaluation(
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION,
             ),
-            meta={},
         )
         core.create_or_get_evaluations(db, job_request_1)
     assert "No models" in str(e)
@@ -327,7 +321,6 @@ def test_fetch_evaluation_from_id(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
     created_1 = core.create_or_get_evaluations(db, job_request_1)
     assert len(created_1) == 1
@@ -341,7 +334,6 @@ def test_fetch_evaluation_from_id(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.SEMANTIC_SEGMENTATION,
         ),
-        meta={},
     )
     created_2 = core.create_or_get_evaluations(db, job_request_2)
     assert len(created_2) == 1
@@ -376,7 +368,6 @@ def test_get_evaluations(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
     created_1 = core.create_or_get_evaluations(db, job_request_1)
     assert len(created_1) == 1
@@ -389,7 +380,6 @@ def test_get_evaluations(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.SEMANTIC_SEGMENTATION,
         ),
-        meta={},
     )
     created_2 = core.create_or_get_evaluations(db, job_request_2)
     assert len(created_2) == 1
@@ -558,7 +548,6 @@ def test_get_evaluation_requests_from_model(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
     core.create_or_get_evaluations(db, job_request_1)
 
@@ -569,7 +558,6 @@ def test_get_evaluation_requests_from_model(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.SEMANTIC_SEGMENTATION,
         ),
-        meta={},
     )
     core.create_or_get_evaluations(db, job_request_2)
 
@@ -600,7 +588,6 @@ def test_evaluation_status(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
     evaluations = core.create_or_get_evaluations(db, job_request_1)
     assert len(evaluations) == 1
@@ -714,7 +701,6 @@ def test_count_active_evaluations(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
     created = core.create_or_get_evaluations(db, job_request_1)
     assert len(created) == 1
@@ -727,7 +713,6 @@ def test_count_active_evaluations(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.SEMANTIC_SEGMENTATION,
         ),
-        meta={},
     )
     created = core.create_or_get_evaluations(db, job_request_2)
     assert len(created) == 1
@@ -774,7 +759,6 @@ def test_count_active_evaluations(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.OBJECT_DETECTION,
         ),
-        meta={},
     )
     evaluation_3 = core.create_or_get_evaluations(db, job_request_3)
     assert len(evaluation_3) == 1
@@ -901,7 +885,6 @@ def test__fetch_evaluations_and_mark_for_deletion(
                     task_type=enums.TaskType.CLASSIFICATION,
                     metrics_to_return=metrics_to_return,
                 ),
-                meta={},
             ),
         )
 

--- a/api/tests/functional-tests/backend/core/test_model.py
+++ b/api/tests/functional-tests/backend/core/test_model.py
@@ -199,7 +199,6 @@ def test_model_status_with_evaluations(
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION,
             ),
-            meta={},
         ),
     )
     assert len(created) == 1

--- a/api/tests/functional-tests/backend/metrics/test_classification.py
+++ b/api/tests/functional-tests/backend/metrics/test_classification.py
@@ -765,7 +765,6 @@ def test_classification(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),
-        meta={},
     )
 
     # creates evaluation job

--- a/api/tests/functional-tests/backend/metrics/test_metric_utils.py
+++ b/api/tests/functional-tests/backend/metrics/test_metric_utils.py
@@ -31,7 +31,6 @@ def test_validate_computation(
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION,
             ),
-            meta={},
         ),
     )
     assert len(created) == 1

--- a/api/tests/functional-tests/backend/metrics/test_segmentation.py
+++ b/api/tests/functional-tests/backend/metrics/test_segmentation.py
@@ -449,7 +449,6 @@ def test_compute_semantic_segmentation_metrics(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.SEMANTIC_SEGMENTATION,
         ),
-        meta={},
     )
 
     evaluations = create_or_get_evaluations(db=db, job_request=job_request)

--- a/api/tests/functional-tests/crud/test_create_delete.py
+++ b/api/tests/functional-tests/crud/test_create_delete.py
@@ -1130,7 +1130,6 @@ def test_create_detection_metrics(
                 iou_thresholds_to_compute=[0.2, 0.6],
                 iou_thresholds_to_return=[0.2],
             ),
-            meta={},
         )
 
         # create evaluation (return AP Response)
@@ -1363,7 +1362,6 @@ def test_create_clf_metrics(
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION
         ),
-        meta={},
     )
 
     # create clf evaluation (returns Clf Response)

--- a/api/tests/functional-tests/crud/test_evaluation_crud.py
+++ b/api/tests/functional-tests/crud/test_evaluation_crud.py
@@ -34,7 +34,6 @@ def test_evaluation_creation_exceptions(db: Session):
                 parameters=schemas.EvaluationParameters(
                     task_type=enums.TaskType.CLASSIFICATION
                 ),
-                meta=None,
             ),
             allow_retries=False,
         )
@@ -50,7 +49,6 @@ def test_evaluation_creation_exceptions(db: Session):
                 parameters=schemas.EvaluationParameters(
                     task_type=enums.TaskType.CLASSIFICATION
                 ),
-                meta=None,
             ),
             allow_retries=False,
         )
@@ -68,7 +66,6 @@ def test_evaluation_creation_exceptions(db: Session):
                 parameters=schemas.EvaluationParameters(
                     task_type=enums.TaskType.CLASSIFICATION
                 ),
-                meta=None,
             ),
             allow_retries=False,
         )
@@ -84,7 +81,6 @@ def test_evaluation_creation_exceptions(db: Session):
                 parameters=schemas.EvaluationParameters(
                     task_type=enums.TaskType.CLASSIFICATION
                 ),
-                meta=None,
             ),
             allow_retries=False,
         )
@@ -116,7 +112,6 @@ def test_evaluation_creation_exceptions(db: Session):
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION
             ),
-            meta=None,
         ),
         allow_retries=False,
     )
@@ -169,7 +164,6 @@ def test_restart_failed_evaluation(db: Session):
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION
             ),
-            meta=None,
         ),
         allow_retries=False,
     )
@@ -194,7 +188,6 @@ def test_restart_failed_evaluation(db: Session):
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION
             ),
-            meta=None,
         ),
         allow_retries=False,
     )
@@ -211,7 +204,6 @@ def test_restart_failed_evaluation(db: Session):
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION
             ),
-            meta=None,
         ),
         allow_retries=True,
     )
@@ -228,7 +220,6 @@ def test_restart_failed_evaluation(db: Session):
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION
             ),
-            meta=None,
         ),
         allow_retries=False,
     )

--- a/api/tests/unit-tests/schemas/test_evaluation.py
+++ b/api/tests/unit-tests/schemas/test_evaluation.py
@@ -83,7 +83,6 @@ def test_EvaluationRequest():
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION
         ),
-        meta={},
     )
     schemas.EvaluationRequest(
         model_names=["name"],
@@ -91,7 +90,6 @@ def test_EvaluationRequest():
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION
         ),
-        meta={},
     )
     schemas.EvaluationRequest(
         model_names=["name", "other"],
@@ -99,7 +97,6 @@ def test_EvaluationRequest():
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION
         ),
-        meta={},
     )
 
     # test missing args
@@ -134,7 +131,6 @@ def test_EvaluationRequest():
             parameters=schemas.EvaluationParameters(
                 task_type=enums.TaskType.CLASSIFICATION
             ),
-            meta={},
         )
 
     # test `datum_filter` validator

--- a/api/tests/unit-tests/test_main.py
+++ b/api/tests/unit-tests/test_main.py
@@ -922,7 +922,6 @@ def test_post_detection_metrics(client: TestClient):
         parameters=schemas.EvaluationParameters(
             task_type=TaskType.OBJECT_DETECTION
         ),
-        meta={},
     ).model_dump()
 
     _test_post_evaluation_endpoint(
@@ -955,7 +954,6 @@ def test_post_clf_metrics(client: TestClient):
         parameters=schemas.EvaluationParameters(
             task_type=TaskType.CLASSIFICATION
         ),
-        meta={},
     ).model_dump()
 
     _test_post_evaluation_endpoint(
@@ -990,7 +988,6 @@ def test_post_semenatic_segmentation_metrics(client: TestClient):
         parameters=schemas.EvaluationParameters(
             task_type=TaskType.SEMANTIC_SEGMENTATION
         ),
-        meta={},
     ).model_dump()
 
     _test_post_evaluation_endpoint(

--- a/api/valor_api/backend/core/evaluation.py
+++ b/api/valor_api/backend/core/evaluation.py
@@ -300,7 +300,6 @@ def _split_request(
             model_names=[model.name],
             datum_filter=job_request.datum_filter,
             parameters=job_request.parameters,
-            meta={},
         )
         for model in models_to_evaluate
     ]
@@ -600,7 +599,7 @@ def create_or_get_evaluations(
                 datum_filter=subrequest.datum_filter.model_dump(),
                 parameters=subrequest.parameters.model_dump(),
                 status=enums.EvaluationStatus.PENDING,
-                meta={},  # meta stores data about the run after it completes; should be an empty dictionary at creation time
+                meta={},
             )
             evaluation = _validate_create_or_get_evaluations(
                 db=db,

--- a/api/valor_api/schemas/evaluation.py
+++ b/api/valor_api/schemas/evaluation.py
@@ -121,14 +121,11 @@ class EvaluationRequest(BaseModel):
         The filter object used to define what datums the model is evaluating over.
     parameters : DetectionParameters, optional
         Any parameters that are used to modify an evaluation method.
-    meta: dict[str, str | int | float]
-        Metadata about the evaluation run
     """
 
     model_names: list[str]
     datum_filter: Filter
     parameters: EvaluationParameters
-    meta: dict[str, str | int | float] | None
 
     # pydantic setting
     model_config = ConfigDict(

--- a/client/unit-tests/schemas/test_evaluation_schemas.py
+++ b/client/unit-tests/schemas/test_evaluation_schemas.py
@@ -11,6 +11,5 @@ def test_evaluation_request():
             "task_type": enums.TaskType.OBJECT_DETECTION.value,
             "convert_annotations_to_type": enums.AnnotationType.BOX.value,
         },
-        "meta": {},
     }
     schemas.EvaluationRequest(**params)

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -910,7 +910,6 @@ class Model(StaticCollection):
                 label_map=self._create_label_map(label_map=label_map),
                 metrics_to_return=metrics_to_return,
             ),
-            meta={},
         )
 
         # create evaluation
@@ -989,7 +988,6 @@ class Model(StaticCollection):
             model_names=[self.name],  # type: ignore
             datum_filter=datum_filter,
             parameters=parameters,
-            meta={},
         )
 
         # create evaluation
@@ -1039,7 +1037,6 @@ class Model(StaticCollection):
                 label_map=self._create_label_map(label_map=label_map),
                 metrics_to_return=metrics_to_return,
             ),
-            meta={},
         )
 
         # create evaluation

--- a/client/valor/schemas/evaluation.py
+++ b/client/valor/schemas/evaluation.py
@@ -54,14 +54,11 @@ class EvaluationRequest:
         The filter object used to define what the model(s) is evaluating against.
     parameters : EvaluationParameters
         Any parameters that are used to modify an evaluation method.
-    meta: dict[str, str | float | dict], optional
-        Metadata about the evaluation run.
     """
 
     model_names: Union[str, List[str]]
     datum_filter: Filter
     parameters: EvaluationParameters
-    meta: Optional[dict]
 
     def __post_init__(self):
         if isinstance(self.datum_filter, dict):

--- a/ts-client/src/ValorClient.ts
+++ b/ts-client/src/ValorClient.ts
@@ -412,7 +412,6 @@ export class ValorClient {
         metrics_to_return: metrics_to_return,
         pr_curve_iou_threshold: prCurveIouThreshold
       },
-      meta: {}
     });
     return this.unmarshalEvaluation(response.data[0]);
   }
@@ -456,7 +455,6 @@ export class ValorClient {
         recall_score_threshold: recallScoreThreshold,
         pr_curve_iou_threshold: prCurveIouThreshold
       },
-      meta: {}
     });
     return response.data.map(this.unmarshalEvaluation);
   }


### PR DESCRIPTION
### Feature Description

Remove the `meta` attribute from `schemas.EvaluationRequest`

### Problem Description

The `meta` attribute in `schemas.EvaluationRequest` is unused as it is a response-only attribute. User-defined evaluation metadata is not stored so this will only cause confusion for the user.

### Additional Context

`meta` is still an attribute of `schemas.EvaluationResponse`