### PR TITLE
Add retry logic to avoid `request` timeouts

### DIFF
--- a/client/unit-tests/coretypes/test_evaluation.py
+++ b/client/unit-tests/coretypes/test_evaluation.py
@@ -26,7 +26,7 @@ def test_to_dataframe():
         id=1,
         dataset_names=["dataset1"],
         model_name="model1",
-        filter=schemas.Filter(),
+        filters=schemas.Filter(),
         parameters=schemas.EvaluationParameters(
             task_type=enums.TaskType.CLASSIFICATION,
         ),

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -26,7 +26,7 @@ from valor.schemas import (
 from valor.schemas import List as SymbolicList
 from valor.schemas import StaticCollection, String
 
-FilterType = Union[list, dict, Filter]  # TODO - Remove  this
+FilterType = Union[list, dict, Filter]  # TODO - Remove this
 
 
 def _format_filter(filter_by: Optional[FilterType]) -> Filter:

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -26,7 +26,7 @@ from valor.schemas import (
 from valor.schemas import List as SymbolicList
 from valor.schemas import StaticCollection, String
 
-FilterType = Union[list, dict, Filter]  # TODO - Remove this
+FilterType = Union[list, dict, Filter]  # TODO - Remove  this
 
 
 def _format_filter(filter_by: Optional[FilterType]) -> Filter:

--- a/integration_tests/client/test_client.py
+++ b/integration_tests/client/test_client.py
@@ -3,6 +3,7 @@ that is no auth
 """
 
 from typing import List
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -173,6 +174,42 @@ def test__requests_wrapper(client: Client):
 
     with pytest.raises(ClientException):
         client.conn._requests_wrapper("get", "not_an_endpoint")
+
+
+@patch("time.sleep")
+def test__requests_wrapper_retries(mock_requests, client: Client, monkeypatch):
+    """Tests the retry logic in _requests_wrapper to see if we call requests.get the appropriate number of times."""
+
+    def _return_mock_response(*args, **kwargs):
+        if mock_requests.call_count <= 3:
+            raise requests.exceptions.Timeout
+        response = requests.Response
+        response.status_code = 200
+        return response
+
+    monkeypatch.setattr("requests.get", _return_mock_response)
+
+    for max_retries in range(1, 3):
+        with pytest.raises(TimeoutError):
+            client.conn._requests_wrapper(
+                method_name="get",
+                endpoint="test",
+                ignore_auth=False,
+                max_retries_on_timeout=max_retries,
+                initial_timeout=0.1,
+                exponential_backoff=1,
+            )
+
+    for max_retries in range(4, 8):
+        client.conn._requests_wrapper(
+            method_name="get",
+            endpoint="test",
+            ignore_auth=False,
+            max_retries_on_timeout=max_retries,
+            initial_timeout=0.1,
+            exponential_backoff=1,
+        )
+        assert mock_requests.call_count == 4
 
 
 def test_get_labels(


### PR DESCRIPTION
# Improvements
- Address #610 by allowing `_requests_wrapper` to retry up to `max_retries_on_timeout` times if a request times out.

```
# max_retries_on_timeout, initial_timeout, and exponential_backoff are new arguments
def _requests_wrapper(
        self,
        method_name: str,
        endpoint: str,
        ignore_auth: bool = False,
        max_retries_on_timeout=2,
        initial_timeout: float = 2,
        exponential_backoff: int = 2,
        *args,
        **kwargs,
    ):
        """
        Wrapper for handling API requests.

        Parameters
        ----------
        method_name : str
            The name of the method to use for the request.
        endpoint : str
            The endpoint to send the request to.
        ignore_auth : bool, default=False
            Option to ignore authentication when you know the endpoint does not
            require a bearer token. this is used by the `_get_access_token_from_username_and_password`
            to avoid infinite recursion.
        max_retries_on_timeout: int
            The maximum number of retries when the requests module returns a Timeout error.
        initial_timeout : float
            The initial timeout value between how often we'll retry request methods.
        exponential_backoff : integer
            The factor by which we multiple initial_timeout for each subsequent retry.
        """
```

# Notes
I looked into swapping requests with urllib3 per Scott's suggestion on slack. I decided not to make this change because:
- requests is basically just urllib3 with syntactic sugar bundled and helpful summary features (e.g., `resp['detail']`). we do use some of these extra features in Valor, so we'd have to recreate them if we want to switch to urllib3
- requests is frequently updated (last commit was 2 weeks ago), is maintained by the Python Software Foundation, and has 50.1k stars on GH; seems fair to say that `requests` is production-ready