### PR TITLE
Classification 

### DIFF
--- a/api/valor_api/backend/metrics/classification.py
+++ b/api/valor_api/backend/metrics/classification.py
@@ -859,7 +859,10 @@ def _compute_confusion_matrix_and_metrics_at_grouper_key(
         ),
     ]
 
-    if "PrecisionRecallCurve" in metrics_to_return:
+    if (
+        "PrecisionRecallCurve" in metrics_to_return
+        or "DetailedPrecisionRecallCurve" in metrics_to_return
+    ):
         # calculate the number of unique datums
         # used to determine the number of true negatives
         gt_datums = generate_query(


### PR DESCRIPTION
# Changes
- To compute `DetailedPrecisionRecallCurve` for classification you no longer need to specify both `PrecisionRecallCurve` and `DetailedPrecisionRecallCurve`.