### PR TITLE
Add Vacuum Analyze to Data Finalization

### DIFF
--- a/api/tests/functional-tests/crud/test_read.py
+++ b/api/tests/functional-tests/crud/test_read.py
@@ -329,7 +329,8 @@ def test_get_dataset_summary(
         enums.TaskType.CLASSIFICATION,
         enums.TaskType.EMPTY,
     }
-    assert summary.datum_metadata == [
+
+    expected_datum_metadata = [
         {
             "width": 32,
             "height": 80,
@@ -339,10 +340,19 @@ def test_get_dataset_summary(
             "height": 100,
         },
     ]
-    assert summary.annotation_metadata == [
+    for item in summary.datum_metadata:
+        assert item in expected_datum_metadata
+    for item in expected_datum_metadata:
+        assert item in summary.datum_metadata
+
+    expected_annotation_metadata = [
         {"int_key": 1},
         {
             "string_key": "string_val",
             "int_key": 1,
         },
     ]
+    for item in summary.annotation_metadata:
+        assert item in expected_annotation_metadata
+    for item in expected_annotation_metadata:
+        assert item in summary.annotation_metadata

--- a/api/valor_api/backend/database.py
+++ b/api/valor_api/backend/database.py
@@ -26,6 +26,21 @@ logger.debug(
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
 
+def vacuum_analyze():
+    pconn = None
+    pcur = None
+    try:
+        pconn = psycopg2.connect(SQLALCHEMY_DATABASE_URL)
+        pcur = pconn.cursor()
+        pconn.autocommit = True
+        pcur.execute("VACUUM ANALYZE;")
+    finally:
+        if pcur is not None:
+            pcur.close()
+        if pconn is not None:
+            pconn.close()
+
+
 def try_to_enable_gdal_drivers(db: Session) -> None:
     """Tries to enable the GDAL drivers for the database. However in some cases
     the application may not have permission to and so that must be taken care of

--- a/api/valor_api/backend/database.py
+++ b/api/valor_api/backend/database.py
@@ -27,6 +27,13 @@ engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
 
 def vacuum_analyze():
+    """
+    Performs a `VACUUM ANALYZE` on the PostgreSQL database.
+
+    This command is used to clean up and optimize the database by reclaiming
+    storage and updating statistics used by the query planner to improve
+    query performance.
+    """
     pconn = None
     pcur = None
     try:

--- a/api/valor_api/backend/database.py
+++ b/api/valor_api/backend/database.py
@@ -34,6 +34,10 @@ def vacuum_analyze():
         pcur = pconn.cursor()
         pconn.autocommit = True
         pcur.execute("VACUUM ANALYZE;")
+    except psycopg2.OperationalError:
+        logger.debug(
+            "Could not connect to postgresql instance to perform vacuum analyze."
+        )
     finally:
         if pcur is not None:
             pcur.close()

--- a/api/valor_api/crud/_update.py
+++ b/api/valor_api/crud/_update.py
@@ -1,10 +1,18 @@
+from fastapi import BackgroundTasks
 from sqlalchemy.orm import Session
 
 from valor_api import enums
 from valor_api.backend import set_dataset_status, set_model_status
+from valor_api.backend.database import vacuum_analyze
 
 
-def finalize(*, db: Session, dataset_name: str, model_name: str | None = None):
+def finalize(
+    *,
+    db: Session,
+    dataset_name: str,
+    model_name: str | None = None,
+    task_handler: BackgroundTasks | None = None,
+):
     """
     Finalizes dataset and dataset/model pairings.
     """
@@ -21,3 +29,8 @@ def finalize(*, db: Session, dataset_name: str, model_name: str | None = None):
             name=dataset_name,
             status=enums.TableStatus.FINALIZED,
         )
+
+    if task_handler:
+        task_handler.add_task(vacuum_analyze)
+    else:
+        vacuum_analyze()

--- a/api/valor_api/main.py
+++ b/api/valor_api/main.py
@@ -736,7 +736,11 @@ def get_dataset_summary(
     dependencies=[Depends(token_auth_scheme)],
     tags=["Datasets"],
 )
-def finalize_dataset(dataset_name: str, db: Session = Depends(get_db)):
+def finalize_dataset(
+    dataset_name: str,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
     """
     Finalizes a dataset for evaluation.
 
@@ -746,6 +750,8 @@ def finalize_dataset(dataset_name: str, db: Session = Depends(get_db)):
     ----------
     dataset_name : str
         The name of the dataset.
+    background_tasks: BackgroundTasks
+        A FastAPI `BackgroundTasks` object to process the creation asynchronously. This parameter is a FastAPI dependency and shouldn't be submitted by the user.
     db : Session
         The database session to use. This parameter is a sqlalchemy dependency and shouldn't be submitted by the user.
 
@@ -758,7 +764,9 @@ def finalize_dataset(dataset_name: str, db: Session = Depends(get_db)):
 
     """
     try:
-        crud.finalize(db=db, dataset_name=dataset_name)
+        crud.finalize(
+            db=db, dataset_name=dataset_name, task_handler=background_tasks
+        )
     except Exception as e:
         raise exceptions.create_http_error(e)
 
@@ -783,7 +791,7 @@ def delete_dataset(
     dataset_name : str
         The name of the dataset.
     background_tasks: BackgroundTasks
-        A FastAPI `BackgroundTasks` object to process the deletion asyncronously. This parameter is a FastAPI dependency and shouldn't be submitted by the user.
+        A FastAPI `BackgroundTasks` object to process the deletion asynchronously. This parameter is a FastAPI dependency and shouldn't be submitted by the user.
     db : Session
         The database session to use. This parameter is a sqlalchemy dependency and shouldn't be submitted by the user.
 
@@ -1238,7 +1246,10 @@ def get_model_status(
     tags=["Models"],
 )
 def finalize_inferences(
-    dataset_name: str, model_name: str, db: Session = Depends(get_db)
+    dataset_name: str,
+    model_name: str,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
 ):
     """
     Finalize a model prior to evaluation.
@@ -1251,6 +1262,8 @@ def finalize_inferences(
         The name of the dataset.
     model_name : str
         The name of the model.
+    background_tasks: BackgroundTasks
+        A FastAPI `BackgroundTasks` object to process the creation asynchronously. This parameter is a FastAPI dependency and shouldn't be submitted by the user.
     db : Session
         The database session to use. This parameter is a sqlalchemy dependency and shouldn't be submitted by the user.
 
@@ -1267,6 +1280,7 @@ def finalize_inferences(
             db=db,
             model_name=model_name,
             dataset_name=dataset_name,
+            task_handler=background_tasks,
         )
     except Exception as e:
         raise exceptions.create_http_error(e)
@@ -1335,7 +1349,7 @@ def create_or_get_evaluations(
     job_request: schemas.EvaluationJob
         The job request for the evaluation.
     background_tasks: BackgroundTasks
-        A FastAPI `BackgroundTasks` object to process the creation asyncronously. This parameter is a FastAPI dependency and shouldn't be submitted by the user.
+        A FastAPI `BackgroundTasks` object to process the creation asynchronously. This parameter is a FastAPI dependency and shouldn't be submitted by the user.
     allow_retries: bool, default = False
         Determines whether failed evaluations are restarted.
     db : Session


### PR DESCRIPTION
On dataset or model finalization a `VACUUM ANALYZE` is called to force the updating of database statistics.

This ensures that any subsequent evaluations will run with consistent completion times.