### PR TITLE
Fixed Bulk Add `DatumAlreadyExistsError` and `AnnotationAlreadyExistsError`

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,14 +4,21 @@ dynamic = ["version"]
 description = "Python client for the Valor evaluation store"
 readme = "README.md"
 requires-python = ">=3.7"
-license = {file = "LICENSE"}
-dependencies = ["requests", "Pillow >= 9.1.0", "numpy", "importlib_metadata; python_version < '3.8'", "tqdm"]
+license = { file = "LICENSE" }
+dependencies = [
+    "requests",
+    "Pillow >= 9.1.0",
+    "numpy",
+    "importlib_metadata; python_version < '3.8'",
+    "tqdm",
+    "packaging",
+]
 
 [project.urls]
 homepage = "https://www.striveworks.com"
 
 [build-system]
-requires =  ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -189,6 +189,7 @@ class ClientConnection:
 
     def _requests_wrapper(
         self,
+        *_,
         method_name: str,
         endpoint: str,
         ignore_auth: bool = False,
@@ -222,6 +223,8 @@ class ClientConnection:
             raise ValueError(
                 f"method_name should be one of {accepted_methods}"
             )
+        elif method_name == "post" and max_retries != 0:
+            raise ValueError("POST requests cannot be automatically retried.")
 
         if endpoint[0] == "/":
             raise ValueError(

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -195,7 +195,6 @@ class ClientConnection:
         timeout: Optional[float] = 2,
         max_retries=2,
         exponential_backoff: int = 2,
-        *args,
         **kwargs,
     ):
         """
@@ -245,7 +244,6 @@ class ClientConnection:
                     url,
                     headers=headers,
                     timeout=timeout,
-                    *args,
                     **kwargs,
                 )
             except requests.exceptions.Timeout as e:
@@ -281,7 +279,6 @@ class ClientConnection:
         endpoint: str,
         timeout: Optional[float] = 2,
         max_retries: int = 0,
-        *args,
         **kwargs,
     ):
         """
@@ -290,10 +287,9 @@ class ClientConnection:
         return self._requests_wrapper(
             method_name="post",
             endpoint=endpoint,
-            max_retries_on_timeout=max_retries,
-            initial_timeout=timeout,
-            *args,
-            *kwargs,
+            max_retries=max_retries,
+            timeout=timeout,
+            **kwargs,
         )
 
     def _requests_get_rel_host(self, endpoint: str, *args, **kwargs):

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -242,7 +242,11 @@ class ClientConnection:
 
             try:
                 resp = requests_method(
-                    url, headers=headers, timeout=10, *args, **kwargs
+                    url,
+                    headers=headers,
+                    timeout=initial_timeout,
+                    *args,
+                    **kwargs,
                 )
             except requests.exceptions.Timeout as e:
                 if timeout_retries < max_retries_on_timeout:
@@ -273,12 +277,24 @@ class ClientConnection:
 
         return resp
 
-    def _requests_post_rel_host(self, endpoint: str, *args, **kwargs):
+    def _requests_post_rel_host(
+        self,
+        endpoint: str,
+        timeout: int = 30,
+        max_retries_on_timeout: int = 0,
+        *args,
+        **kwargs,
+    ):
         """
         Helper for handling POST requests.
         """
         return self._requests_wrapper(
-            method_name="post", endpoint=endpoint, *args, **kwargs
+            method_name="post",
+            endpoint=endpoint,
+            max_retries_on_timeout=max_retries_on_timeout,
+            initial_timeout=timeout,
+            *args,
+            *kwargs,
         )
 
     def _requests_get_rel_host(self, endpoint: str, *args, **kwargs):

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -138,6 +138,11 @@ class ClientConnection:
         else:
             self._using_username_password = False
 
+        if self.access_token or self._using_username_password:
+            self._using_auth = True
+        else:
+            self._using_auth = False
+
         # check the connection by getting the api version number
         try:
             api_version = self.get_api_version()
@@ -193,9 +198,7 @@ class ClientConnection:
         method_name: str,
         endpoint: str,
         ignore_auth: bool = False,
-        timeout: Optional[float] = 2,
-        max_retries=2,
-        exponential_backoff: int = 2,
+        timeout: Optional[float] = 10,
         **kwargs,
     ):
         """
@@ -212,19 +215,13 @@ class ClientConnection:
             require a bearer token. this is used by the `_get_access_token_from_username_and_password`
             to avoid infinite recursion.
         timeout : float, optional
-            The initial timeout value between how often we'll retry request methods.
-        max_retries: int
-            The maximum number of retries when the requests module returns a Timeout error.
-        exponential_backoff : integer
-            The factor by which we multiple initial_timeout for each subsequent retry.
+            An optional request timeout in seconds.
         """
         accepted_methods = ["get", "post", "put", "delete"]
         if method_name not in accepted_methods:
             raise ValueError(
                 f"method_name should be one of {accepted_methods}"
             )
-        elif method_name == "post" and max_retries != 0:
-            raise ValueError("POST requests cannot be automatically retried.")
 
         if endpoint[0] == "/":
             raise ValueError(
@@ -234,90 +231,118 @@ class ClientConnection:
         url = urljoin(self.host, endpoint)
         requests_method = getattr(requests, method_name)
 
-        timeout_retries = 0
-        tried = False
-        while True:
-            if self.access_token is not None:
-                headers = {"Authorization": f"Bearer {self.access_token}"}
-            else:
-                headers = None
+        if not ignore_auth and self._using_auth:
+            # get a new token
+            if self._using_username_password:
+                self._get_access_token_from_username_and_password()
+            headers = {"Authorization": f"Bearer {self.access_token}"}
+        else:
+            headers = None
 
-            try:
-                resp = requests_method(
-                    url,
-                    headers=headers,
-                    timeout=timeout,
-                    **kwargs,
-                )
-            except requests.exceptions.Timeout as e:
-                if timeout is not None and timeout_retries < max_retries:
-                    time.sleep(
-                        timeout * exponential_backoff**timeout_retries
-                    )
-                    timeout_retries += 1
-                    continue
-                else:
-                    raise TimeoutError(str(e))
-
-            if not resp.ok:
-                # check if unauthorized and if using username and password, get a new
-                # token and try the request again
-                if (
-                    resp.status_code in [401, 403]
-                    and self._using_username_password
-                    and not tried
-                    and not ignore_auth
-                ):
-                    self._get_access_token_from_username_and_password()
-                else:
-                    raise_client_exception(resp)
-            else:
-                break
-            tried = True
+        resp = requests_method(
+            url,
+            headers=headers,
+            timeout=timeout,
+            **kwargs,
+        )
+        if not resp.ok:
+            raise_client_exception(resp)
 
         return resp
 
     def _requests_post_rel_host(
         self,
         endpoint: str,
-        timeout: Optional[float] = 2,
-        max_retries: int = 0,
-        **kwargs,
+        *_,
+        json: Union[dict, list, None] = None,
+        params: Union[dict, list, None] = None,
+        data: Optional[dict] = None,
+        ignore_auth: bool = False,
+        timeout: Optional[float] = 10,
     ):
         """
         Helper for handling POST requests.
+
+        Parameters
+        ----------
+        endpoint : str
+            The endpoint to send the request to.
+        json : dict | list, optional
+            An optional kwarg to pass to the request.
+        params : dict, optional
+            An optional kwarg to pass to the request.
+        data : dict, optional
+            An optional kwarg to pass to the request.
+        ignore_auth : bool, default=False
+            Option to ignore authentication when you know the endpoint does not
+            require a bearer token. this is used by the `_get_access_token_from_username_and_password`
+            to avoid infinite recursion.
+        timeout : float | None, default=10
+            An optional request timeout in seconds.
         """
         return self._requests_wrapper(
             method_name="post",
             endpoint=endpoint,
-            max_retries=max_retries,
+            json=json,
+            params=params,
+            data=data,
+            ignore_auth=ignore_auth,
             timeout=timeout,
-            **kwargs,
         )
 
-    def _requests_get_rel_host(self, endpoint: str, *args, **kwargs):
+    def _requests_get_rel_host(
+        self,
+        endpoint: str,
+        *_,
+        timeout: Optional[float] = 10,
+    ):
         """
         Helper for handling GET requests.
-        """
-        return self._requests_wrapper(
-            method_name="get", endpoint=endpoint, *args, **kwargs
-        )
 
-    def _requests_put_rel_host(self, endpoint: str, *args, **kwargs):
+        Parameters
+        ----------
+        endpoint : str
+            The endpoint to send the request to.
+        timeout : float | None, default=10
+            An optional request timeout in seconds.
+        """
+        return self._requests_wrapper(method_name="get", endpoint=endpoint)
+
+    def _requests_put_rel_host(
+        self,
+        endpoint: str,
+        *_,
+        timeout: Optional[float] = 10,
+    ):
         """
         Helper for handling PUT requests.
-        """
-        return self._requests_wrapper(
-            method_name="put", endpoint=endpoint, *args, **kwargs
-        )
 
-    def _requests_delete_rel_host(self, endpoint: str, *args, **kwargs):
+        Parameters
+        ----------
+        endpoint : str
+            The endpoint to send the request to.
+        timeout : float | None, default=10
+            An optional request timeout in seconds.
+        """
+        return self._requests_wrapper(method_name="put", endpoint=endpoint)
+
+    def _requests_delete_rel_host(
+        self,
+        endpoint: str,
+        *_,
+        timeout: Optional[float] = 10,
+    ):
         """
         Helper for handling DELETE requests.
+
+        Parameters
+        ----------
+        endpoint : str
+            The endpoint to send the request to.
+        timeout : float | None, default=10
+            An optional request timeout in seconds.
         """
-        return self._requests_wrapper(
-            method_name="delete", endpoint=endpoint, *args, **kwargs
-        )
+        return self._requests_wrapper(method_name="delete", endpoint=endpoint)
 
     def create_groundtruths(
         self,

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -275,7 +275,7 @@ class ClientConnection:
             An optional kwarg to pass to the request.
         ignore_auth : bool, default=False
             Option to ignore authentication when you know the endpoint does not
-            require a bearer token. this is used by the `_get_access_token_from_username_and_password`
+            require a bearer token. This is used by the `_get_access_token_from_username_and_password`
             to avoid infinite recursion.
         timeout : float | None, default=10
             An optional request timeout in seconds.

--- a/client/valor/client.py
+++ b/client/valor/client.py
@@ -192,7 +192,7 @@ class ClientConnection:
         method_name: str,
         endpoint: str,
         ignore_auth: bool = False,
-        timeout: float | None = 2,
+        timeout: Optional[float] = 2,
         max_retries=2,
         exponential_backoff: int = 2,
         *args,
@@ -279,7 +279,7 @@ class ClientConnection:
     def _requests_post_rel_host(
         self,
         endpoint: str,
-        timeout: float | None = 2,
+        timeout: Optional[float] = 2,
         max_retries: int = 0,
         *args,
         **kwargs,
@@ -323,7 +323,7 @@ class ClientConnection:
     def create_groundtruths(
         self,
         groundtruths: List[dict],
-        timeout: float | None,
+        timeout: Optional[float],
         ignore_existing_datums: bool = False,
     ) -> None:
         """
@@ -378,7 +378,7 @@ class ClientConnection:
     def create_predictions(
         self,
         predictions: List[dict],
-        timeout: float | None,
+        timeout: Optional[float],
     ) -> None:
         """
         Creates predictions.

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -465,7 +465,7 @@ class Dataset(StaticCollection):
         self,
         groundtruths: List[GroundTruth],
         ignore_existing_datums: bool = False,
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 10.0,
     ) -> None:
         """
         Add multiple ground truths to the dataset.
@@ -734,7 +734,7 @@ class Model(StaticCollection):
         self,
         dataset: Dataset,
         predictions: List[Prediction],
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 10.0,
     ) -> None:
         """
         Add multiple predictions to the model.

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -465,7 +465,7 @@ class Dataset(StaticCollection):
         self,
         groundtruths: List[GroundTruth],
         ignore_existing_datums: bool = False,
-        timeout: float | None = None,
+        timeout: Optional[float] = None,
     ) -> None:
         """
         Add multiple ground truths to the dataset.
@@ -734,7 +734,7 @@ class Model(StaticCollection):
         self,
         dataset: Dataset,
         predictions: List[Prediction],
-        timeout: float | None = None,
+        timeout: Optional[float] = None,
     ) -> None:
         """
         Add multiple predictions to the model.
@@ -1203,7 +1203,7 @@ class Client:
         dataset: Dataset,
         groundtruths: List[GroundTruth],
         ignore_existing_datums: bool = False,
-        timeout: float | None = None,
+        timeout: Optional[float] = None,
     ):
         """
         Creates ground truths.
@@ -1471,7 +1471,7 @@ class Client:
         dataset: Dataset,
         model: Model,
         predictions: List[Prediction],
-        timeout: float | None = None,
+        timeout: Optional[float] = None,
     ) -> None:
         """
         Creates predictions.

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -465,6 +465,7 @@ class Dataset(StaticCollection):
         self,
         groundtruths: List[GroundTruth],
         ignore_existing_datums: bool = False,
+        timeout: float | None = None,
     ) -> None:
         """
         Add multiple ground truths to the dataset.
@@ -477,11 +478,14 @@ class Dataset(StaticCollection):
             If True, will ignore datums that already exist in the backend.
             If False, will raise an error if any datums already exist.
             Default is False.
+        timeout: float, optional
+            The number of seconds the client should wait until raising a timeout.
         """
         Client(self.conn).create_groundtruths(
             dataset=self,
             groundtruths=groundtruths,
             ignore_existing_datums=ignore_existing_datums,
+            timeout=timeout,
         )
 
     def get_groundtruth(
@@ -730,6 +734,7 @@ class Model(StaticCollection):
         self,
         dataset: Dataset,
         predictions: List[Prediction],
+        timeout: float | None = None,
     ) -> None:
         """
         Add multiple predictions to the model.
@@ -740,11 +745,14 @@ class Model(StaticCollection):
             The dataset that is being operated over.
         predictions : List[valor.Prediction]
             The predictions to create.
+        timeout: float, optional
+            The number of seconds the client should wait until raising a timeout.
         """
         Client(self.conn).create_predictions(
             dataset=dataset,
             model=self,
             predictions=predictions,
+            timeout=timeout,
         )
 
     def get_prediction(
@@ -1195,6 +1203,7 @@ class Client:
         dataset: Dataset,
         groundtruths: List[GroundTruth],
         ignore_existing_datums: bool = False,
+        timeout: float | None = None,
     ):
         """
         Creates ground truths.
@@ -1206,6 +1215,8 @@ class Client:
             The dataset to create the ground truth for.
         groundtruths : List[valor.GroundTruth]
             The ground truths to create.
+        timeout: float, optional
+            The number of seconds the client should wait until raising a timeout.
         ignore_existing_datums : bool, default=False
             If True, will ignore datums that already exist in the backend.
             If False, will raise an error if any datums already exist.
@@ -1223,7 +1234,9 @@ class Client:
             groundtruth_dict["dataset_name"] = dataset.name
             groundtruths_json.append(groundtruth_dict)
         self.conn.create_groundtruths(
-            groundtruths_json, ignore_existing_datums=ignore_existing_datums
+            groundtruths_json,
+            timeout=timeout,
+            ignore_existing_datums=ignore_existing_datums,
         )
 
     def get_groundtruth(
@@ -1458,6 +1471,7 @@ class Client:
         dataset: Dataset,
         model: Model,
         predictions: List[Prediction],
+        timeout: float | None = None,
     ) -> None:
         """
         Creates predictions.
@@ -1470,6 +1484,8 @@ class Client:
             The model making the prediction.
         predictions : List[valor.Prediction]
             The predictions to create.
+        timeout: float, optional
+            The number of seconds the client should wait until raising a timeout.
         """
         predictions_json = []
         for prediction in predictions:
@@ -1483,7 +1499,7 @@ class Client:
             prediction_dict["dataset_name"] = dataset.name
             prediction_dict["model_name"] = model.name
             predictions_json.append(prediction_dict)
-        self.conn.create_predictions(predictions_json)
+        self.conn.create_predictions(predictions_json, timeout=timeout)
 
     def get_prediction(
         self,

--- a/client/valor/coretypes.py
+++ b/client/valor/coretypes.py
@@ -1203,7 +1203,7 @@ class Client:
         dataset: Dataset,
         groundtruths: List[GroundTruth],
         ignore_existing_datums: bool = False,
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 10,
     ):
         """
         Creates ground truths.
@@ -1471,7 +1471,7 @@ class Client:
         dataset: Dataset,
         model: Model,
         predictions: List[Prediction],
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 10,
     ) -> None:
         """
         Creates predictions.

--- a/integration_tests/client/test_client.py
+++ b/integration_tests/client/test_client.py
@@ -253,30 +253,17 @@ def test__requests_wrapper_retries_without_timeout(mock_get, client: Client):
     assert mock_get.call_count == 2 + max_retries
 
 
-def test_request_timeout(client: Client):
-
-    client.conn._requests_wrapper(
-        method_name="get",
-        endpoint="labels",
-        ignore_auth=False,
-        timeout=None,
-        max_retries=0,
-        exponential_backoff=1,
-    )
-
+def test__requests_wrapper_post_cannot_retry(client: Client):
     with pytest.raises(ValueError) as e:
         client.conn._requests_wrapper(
-            method_name="get",
-            endpoint="labels",
+            method_name="post",
+            endpoint="test",
             ignore_auth=False,
-            timeout=0,
-            max_retries=0,
+            timeout=0.1,
+            max_retries=2,
             exponential_backoff=1,
         )
-    assert (
-        "Attempted to set connect timeout to 0, but the timeout cannot be set to a value less than or equal to 0."
-        in str(e)
-    )
+    assert "POST requests cannot be automatically retried." in str(e)
 
 
 def test_get_labels(

--- a/integration_tests/client/test_client.py
+++ b/integration_tests/client/test_client.py
@@ -195,8 +195,8 @@ def test__requests_wrapper_retries(mock_requests, client: Client, monkeypatch):
                 method_name="get",
                 endpoint="test",
                 ignore_auth=False,
-                max_retries_on_timeout=max_retries,
-                initial_timeout=0.1,
+                timeout=0.1,
+                max_retries=max_retries,
                 exponential_backoff=1,
             )
 
@@ -205,8 +205,8 @@ def test__requests_wrapper_retries(mock_requests, client: Client, monkeypatch):
             method_name="get",
             endpoint="test",
             ignore_auth=False,
-            max_retries_on_timeout=max_retries,
-            initial_timeout=0.1,
+            timeout=0.1,
+            max_retries=max_retries,
             exponential_backoff=1,
         )
         assert mock_requests.call_count == 4


### PR DESCRIPTION
# Issue
The default timeout was 10s for all requests in the python client. For most requests this is fine, but for bulk add where a large JSON payload would have to be parsed by the API this would cause an early timeout.

This would have been caught earlier but the python client would perform automatic retrying of the POST request. This would immediately cause a conflict on the API-side as the already existing data was being uploaded.

### Example
The following shows the same request being resent without the knowledge of the user. The "retry" immediately fails because it directly conflicts with the original request.
```
{"method": "POST", "path": "/predictions", "hostname": "0.0.0.0", "status": 200, "duration_ms": 12469.926136996946, ...
{"method": "POST", "path": "/predictions", "hostname": "0.0.0.0", "status": 409, "duration_ms": 557.2792300081346, ...
```

# Solution
- remove retrying client requests, this exposes the issue so the user can retry the command themselves.
- expose timeout at the highest level so that it can be dynamically set by the user.