### PR TITLE
Update PR Curve definitions for Classification

### DIFF
--- a/api/tests/functional-tests/backend/metrics/test_classification.py
+++ b/api/tests/functional-tests/backend/metrics/test_classification.py
@@ -1349,39 +1349,36 @@ def test__compute_curves(
         # bird
         ("bird", 0.05, "tp"): {"all": 3, "total": 3},
         ("bird", 0.05, "fp"): {
-            "hallucinations": 0,
             "misclassifications": 1,
             "total": 1,
         },
         ("bird", 0.05, "tn"): {"all": 2, "total": 2},
         ("bird", 0.05, "fn"): {
-            "missed_detections": 0,
+            "null_prediction": 0,
             "misclassifications": 0,
             "total": 0,
         },
         # dog
         ("dog", 0.05, "tp"): {"all": 2, "total": 2},
         ("dog", 0.05, "fp"): {
-            "hallucinations": 0,
             "misclassifications": 3,
             "total": 3,
         },
         ("dog", 0.05, "tn"): {"all": 1, "total": 1},
         ("dog", 0.8, "fn"): {
-            "missed_detections": 1,
+            "null_prediction": 1,
             "misclassifications": 1,
             "total": 2,
         },
         # cat
         ("cat", 0.05, "tp"): {"all": 1, "total": 1},
         ("cat", 0.05, "fp"): {
-            "hallucinations": 0,
             "misclassifications": 5,
             "total": 5,
         },
         ("cat", 0.05, "tn"): {"all": 0, "total": 0},
         ("cat", 0.8, "fn"): {
-            "missed_detections": 0,
+            "null_prediction": 0,
             "misclassifications": 0,
             "total": 0,
         },

--- a/api/tests/functional-tests/backend/metrics/test_classification.py
+++ b/api/tests/functional-tests/backend/metrics/test_classification.py
@@ -1354,7 +1354,7 @@ def test__compute_curves(
         },
         ("bird", 0.05, "tn"): {"all": 2, "total": 2},
         ("bird", 0.05, "fn"): {
-            "null_prediction": 0,
+            "no_prediction": 0,
             "misclassifications": 0,
             "total": 0,
         },
@@ -1366,7 +1366,7 @@ def test__compute_curves(
         },
         ("dog", 0.05, "tn"): {"all": 1, "total": 1},
         ("dog", 0.8, "fn"): {
-            "null_prediction": 1,
+            "no_prediction": 1,
             "misclassifications": 1,
             "total": 2,
         },
@@ -1378,7 +1378,7 @@ def test__compute_curves(
         },
         ("cat", 0.05, "tn"): {"all": 0, "total": 0},
         ("cat", 0.8, "fn"): {
-            "null_prediction": 0,
+            "no_prediction": 0,
             "misclassifications": 0,
             "total": 0,
         },

--- a/api/tests/functional-tests/backend/metrics/test_classification.py
+++ b/api/tests/functional-tests/backend/metrics/test_classification.py
@@ -1354,7 +1354,7 @@ def test__compute_curves(
         },
         ("bird", 0.05, "tn"): {"all": 2, "total": 2},
         ("bird", 0.05, "fn"): {
-            "no_prediction": 0,
+            "no_predictions": 0,
             "misclassifications": 0,
             "total": 0,
         },
@@ -1366,7 +1366,7 @@ def test__compute_curves(
         },
         ("dog", 0.05, "tn"): {"all": 1, "total": 1},
         ("dog", 0.8, "fn"): {
-            "no_prediction": 1,
+            "no_predictions": 1,
             "misclassifications": 1,
             "total": 2,
         },
@@ -1378,7 +1378,7 @@ def test__compute_curves(
         },
         ("cat", 0.05, "tn"): {"all": 0, "total": 0},
         ("cat", 0.8, "fn"): {
-            "no_prediction": 0,
+            "no_predictions": 0,
             "misclassifications": 0,
             "total": 0,
         },

--- a/api/tests/functional-tests/backend/metrics/test_detection.py
+++ b/api/tests/functional-tests/backend/metrics/test_detection.py
@@ -826,20 +826,20 @@ def test__compute_detailed_curves(db: Session):
         # (class, 4)
         ("4", 0.05, "tp"): {"all": 2, "total": 2},
         ("4", 0.05, "fn"): {
-            "missed_detections": 0,
+            "no_predictions": 0,
             "misclassifications": 0,
             "total": 0,
         },
         # (class, 2)
         ("2", 0.05, "tp"): {"all": 1, "total": 1},
         ("2", 0.05, "fn"): {
-            "missed_detections": 0,
+            "no_predictions": 0,
             "misclassifications": 1,
             "total": 1,
         },
         ("2", 0.75, "tp"): {"all": 0, "total": 0},
         ("2", 0.75, "fn"): {
-            "missed_detections": 2,
+            "no_predictions": 2,
             "misclassifications": 0,
             "total": 2,
         },
@@ -855,14 +855,14 @@ def test__compute_detailed_curves(db: Session):
         # (class, 1)
         ("1", 0.05, "tp"): {"all": 1, "total": 1},
         ("1", 0.8, "fn"): {
-            "missed_detections": 1,
+            "no_predictions": 1,
             "misclassifications": 0,
             "total": 1,
         },
         # (class, 0)
         ("0", 0.05, "tp"): {"all": 5, "total": 5},
         ("0", 0.95, "fn"): {
-            "missed_detections": 4,
+            "no_predictions": 4,
             "misclassifications": 0,
             "total": 4,
         },
@@ -891,7 +891,7 @@ def test__compute_detailed_curves(db: Session):
     # spot check number of examples
     assert (
         len(
-            output[1].value["0"][0.95]["fn"]["observations"]["missed_detections"][  # type: ignore - we know this element is a dict
+            output[1].value["0"][0.95]["fn"]["observations"]["no_predictions"][  # type: ignore - we know this element is a dict
                 "examples"
             ]
         )
@@ -956,20 +956,20 @@ def test__compute_detailed_curves(db: Session):
         # (class, 4)
         ("4", 0.05, "tp"): {"all": 0, "total": 0},
         ("4", 0.05, "fn"): {
-            "missed_detections": 2,  # below IOU threshold of .9
+            "no_predictions": 2,  # below IOU threshold of .9
             "misclassifications": 0,
             "total": 2,
         },
         # (class, 2)
         ("2", 0.05, "tp"): {"all": 1, "total": 1},
         ("2", 0.05, "fn"): {
-            "missed_detections": 1,
+            "no_predictions": 1,
             "misclassifications": 0,
             "total": 1,
         },
         ("2", 0.75, "tp"): {"all": 0, "total": 0},
         ("2", 0.75, "fn"): {
-            "missed_detections": 2,
+            "no_predictions": 2,
             "misclassifications": 0,
             "total": 2,
         },
@@ -985,14 +985,14 @@ def test__compute_detailed_curves(db: Session):
         # (class, 1)
         ("1", 0.05, "tp"): {"all": 0, "total": 0},
         ("1", 0.8, "fn"): {
-            "missed_detections": 1,
+            "no_predictions": 1,
             "misclassifications": 0,
             "total": 1,
         },
         # (class, 0)
         ("0", 0.05, "tp"): {"all": 1, "total": 1},
         ("0", 0.95, "fn"): {
-            "missed_detections": 5,
+            "no_predictions": 5,
             "misclassifications": 0,
             "total": 5,
         },
@@ -1021,7 +1021,7 @@ def test__compute_detailed_curves(db: Session):
     # spot check number of examples
     assert (
         len(
-            second_output[1].value["0"][0.95]["fn"]["observations"]["missed_detections"][  # type: ignore - we know this element is a dict
+            second_output[1].value["0"][0.95]["fn"]["observations"]["no_predictions"][  # type: ignore - we know this element is a dict
                 "examples"
             ]
         )
@@ -1069,7 +1069,7 @@ def test__compute_detailed_curves(db: Session):
     # spot check number of examples
     assert (
         len(
-            second_output[1].value["0"][0.95]["fn"]["observations"]["missed_detections"][  # type: ignore - we know this element is a dict
+            second_output[1].value["0"][0.95]["fn"]["observations"]["no_predictions"][  # type: ignore - we know this element is a dict
                 "examples"
             ]
         )
@@ -1117,7 +1117,7 @@ def test__compute_detailed_curves(db: Session):
     # spot check number of examples
     assert (
         len(
-            second_output[1].value["0"][0.95]["fn"]["observations"]["missed_detections"][  # type: ignore - we know this element is a dict
+            second_output[1].value["0"][0.95]["fn"]["observations"]["no_predictions"][  # type: ignore - we know this element is a dict
                 "examples"
             ]
         )

--- a/api/valor_api/backend/metrics/classification.py
+++ b/api/valor_api/backend/metrics/classification.py
@@ -147,7 +147,7 @@ def _compute_curves(
         )
 
         # create sets of all datums for which there is a prediction / groundtruth
-        # used when separating misclassifications/null_prediction
+        # used when separating misclassifications/no_prediction
         gt_datums = set()
         pd_datums = set()
 
@@ -203,7 +203,7 @@ def _compute_curves(
                             (gt_dataset_name, gt_datum_uid)
                         )
                     else:
-                        fn["null_prediction"].append(
+                        fn["no_prediction"].append(
                             (gt_dataset_name, gt_datum_uid)
                         )
                     seen_datums.add(gt_datum_uid)
@@ -216,13 +216,13 @@ def _compute_curves(
                 not in tp
                 + fp["misclassifications"]
                 + fn["misclassifications"]
-                + fn["null_prediction"]
+                + fn["no_prediction"]
                 and None not in datum_uid_pair
             ]
             tp_cnt, fp_cnt, fn_cnt, tn_cnt = (
                 len(tp),
                 len(fp["misclassifications"]),
-                len(fn["null_prediction"]) + len(fn["misclassifications"]),
+                len(fn["no_prediction"]) + len(fn["misclassifications"]),
                 len(tn),
             )
 
@@ -301,16 +301,16 @@ def _compute_curves(
                                     else fn["misclassifications"]
                                 ),
                             },
-                            "null_prediction": {
-                                "count": len(fn["null_prediction"]),
+                            "no_prediction": {
+                                "count": len(fn["no_prediction"]),
                                 "examples": (
                                     random.sample(
-                                        fn["null_prediction"],
+                                        fn["no_prediction"],
                                         pr_curve_max_examples,
                                     )
-                                    if len(fn["null_prediction"])
+                                    if len(fn["no_prediction"])
                                     >= pr_curve_max_examples
-                                    else fn["null_prediction"]
+                                    else fn["no_prediction"]
                                 ),
                             },
                         },

--- a/api/valor_api/backend/metrics/classification.py
+++ b/api/valor_api/backend/metrics/classification.py
@@ -69,7 +69,7 @@ def _compute_curves(
     ]
 
     # create sets of all datums for which there is a prediction / groundtruth
-    # used when separating misclassifications/missed_detections
+    # used when separating misclassifications/no_predictions
     pd_datum_ids_to_high_score = {
         datum_id: high_score
         for datum_id, high_score in db.query(
@@ -185,7 +185,7 @@ def _compute_curves(
                     ):
                         fn["misclassifications"].add(gt_datum_id)
                     else:
-                        fn["missed_detections"].add(gt_datum_id)
+                        fn["no_predictions"].add(gt_datum_id)
                     seen_datum_ids.add(gt_datum_id)
 
             tn = set(unique_datums.keys()) - seen_datum_ids

--- a/api/valor_api/backend/metrics/classification.py
+++ b/api/valor_api/backend/metrics/classification.py
@@ -203,7 +203,7 @@ def _compute_curves(
                             (gt_dataset_name, gt_datum_uid)
                         )
                     else:
-                        fn["no_prediction"].append(
+                        fn["no_predictions"].append(
                             (gt_dataset_name, gt_datum_uid)
                         )
                     seen_datums.add(gt_datum_uid)
@@ -216,13 +216,13 @@ def _compute_curves(
                 not in tp
                 + fp["misclassifications"]
                 + fn["misclassifications"]
-                + fn["no_prediction"]
+                + fn["no_predictions"]
                 and None not in datum_uid_pair
             ]
             tp_cnt, fp_cnt, fn_cnt, tn_cnt = (
                 len(tp),
                 len(fp["misclassifications"]),
-                len(fn["no_prediction"]) + len(fn["misclassifications"]),
+                len(fn["no_predictions"]) + len(fn["misclassifications"]),
                 len(tn),
             )
 
@@ -301,16 +301,16 @@ def _compute_curves(
                                     else fn["misclassifications"]
                                 ),
                             },
-                            "no_prediction": {
-                                "count": len(fn["no_prediction"]),
+                            "no_predictions": {
+                                "count": len(fn["no_predictions"]),
                                 "examples": (
                                     random.sample(
-                                        fn["no_prediction"],
+                                        fn["no_predictions"],
                                         pr_curve_max_examples,
                                     )
-                                    if len(fn["no_prediction"])
+                                    if len(fn["no_predictions"])
                                     >= pr_curve_max_examples
-                                    else fn["no_prediction"]
+                                    else fn["no_predictions"]
                                 ),
                             },
                         },

--- a/api/valor_api/backend/metrics/detection.py
+++ b/api/valor_api/backend/metrics/detection.py
@@ -364,7 +364,7 @@ def _compute_detailed_curves(
 
     # transform sorted_ranked_pairs into two sets (groundtruths and predictions)
     # we'll use these dictionaries to look up the IOU overlap between specific groundtruths and predictions
-    # to separate misclassifications from hallucinations/missed_detections
+    # to separate misclassifications
     pd_datums = defaultdict(lambda: defaultdict(list))
     gt_datums = defaultdict(lambda: defaultdict(list))
 

--- a/api/valor_api/backend/metrics/detection.py
+++ b/api/valor_api/backend/metrics/detection.py
@@ -466,7 +466,7 @@ def _compute_detailed_curves(
                                 (dataset_name, datum_uid, gt_geojson)
                             )
                         else:
-                            fn["missed_detections"].append(
+                            fn["no_predictions"].append(
                                 (dataset_name, datum_uid, gt_geojson)
                             )
 
@@ -521,7 +521,7 @@ def _compute_detailed_curves(
             tp_cnt, fp_cnt, fn_cnt = (
                 len(tp),
                 len(fp["hallucinations"]) + len(fp["misclassifications"]),
-                len(fn["missed_detections"]) + len(fn["misclassifications"]),
+                len(fn["no_predictions"]) + len(fn["misclassifications"]),
             )
             precision = (
                 tp_cnt / (tp_cnt + fp_cnt) if (tp_cnt + fp_cnt) > 0 else -1
@@ -575,16 +575,16 @@ def _compute_detailed_curves(
                                 else fn["misclassifications"]
                             ),
                         },
-                        "missed_detections": {
-                            "count": len(fn["missed_detections"]),
+                        "no_predictions": {
+                            "count": len(fn["no_predictions"]),
                             "examples": (
                                 random.sample(
-                                    fn["missed_detections"],
+                                    fn["no_predictions"],
                                     pr_curve_max_examples,
                                 )
-                                if len(fn["missed_detections"])
+                                if len(fn["no_predictions"])
                                 >= pr_curve_max_examples
-                                else fn["missed_detections"]
+                                else fn["no_predictions"]
                             ),
                         },
                     },

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -222,8 +222,8 @@ Valor also includes a more detailed version of `PrecisionRecallCurve` which can 
     - **Example**: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another label value (e.g., `Label(key='animal', value='cat')`) on that datum, we'd say it's a `misclassification` since the key was correct but the value was not.
   - Similarly, a **false negative** occurs when there is a prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect.
     - Stratifications of False Negatives:
-        - **Misclassification**: Occurs when a different label value passes the score threshold.
-        - **Null Prediction**: Occurs when no label passes the score threshold.
+        - `misclassification`: Occurs when a different label value passes the score threshold.
+        - `no_prediction`: Occurs when no label passes the score threshold.
 
 #### Object Detection Tasks
   - A **false positive** is a `misclassification` if a) there is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect, and b) the qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`. For example: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another bounding box directly over that same object (e.g., `Label(key='animal', value='cat')`), we'd say it's a `misclassification`. Any false positives that do not meet this criteria are considered to be `hallucinations`.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -218,8 +218,12 @@ The `PrecisionRecallCurve` values differ from the precision-recall curves used t
 Valor also includes a more detailed version of `PrecisionRecallCurve` which can be useful for debugging your model's false positives and false negatives. When calculating `DetailedPrecisionCurve`, Valor will classify false positives as either `hallucinations` or `misclassifications` and your false negatives as either `missed_detections` or `misclassifications` using the following logic:
 
 #### Classification Tasks
-  - A **false positive** is a `misclassification` if there is a qualified prediction (with `score >= score_threshold`) with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect. For example: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another label value (e.g., `Label(key='animal', value='cat')`) on that datum, we'd say it's a `misclassification` since the key was correct but the value was not. Any false positives that do not meet this criteria are considered to be `hallucinations`.
-  - Similarly, a **false negative** is a `misclassification` if there is a prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect. Any false negatives that do not meet this criteria are considered to be `missed_detections`.
+  - A **false positive** occurs when there is a qualified prediction (with `score >= score_threshold`) with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect.
+    - **Example**: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another label value (e.g., `Label(key='animal', value='cat')`) on that datum, we'd say it's a `misclassification` since the key was correct but the value was not.
+  - Similarly, a **false negative** occurs when there is a prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect.
+    - Stratifications of False Negatives:
+        - **Misclassification**: Occurs when a different label value passes the score threshold.
+        - **Null Prediction**: Occurs when no label passes the score threshold.
 
 #### Object Detection Tasks
   - A **false positive** is a `misclassification` if a) there is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect, and b) the qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`. For example: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another bounding box directly over that same object (e.g., `Label(key='animal', value='cat')`), we'd say it's a `misclassification`. Any false positives that do not meet this criteria are considered to be `hallucinations`.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -223,11 +223,18 @@ Valor also includes a more detailed version of `PrecisionRecallCurve` which can 
   - Similarly, a **false negative** occurs when there is a prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect.
     - Stratifications of False Negatives:
         - `misclassification`: Occurs when a different label value passes the score threshold.
-        - `no_prediction`: Occurs when no label passes the score threshold.
+        - `no_predictions`: Occurs when no label passes the score threshold.
 
 #### Object Detection Tasks
-  - A **false positive** is a `misclassification` if a) there is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect, and b) the qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`. For example: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another bounding box directly over that same object (e.g., `Label(key='animal', value='cat')`), we'd say it's a `misclassification`. Any false positives that do not meet this criteria are considered to be `hallucinations`.
-  - A **false negative** is determined to be a `misclassification` if the two criteria above are met: a) there is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect, and b) the qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`. Any false negatives that do not meet this criteria are considered to be `missed_detections`.
+    - A **false positive** is a `misclassification` if the following conditions are met:
+        1. There is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect
+        2. The qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`.
+        - For example: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another bounding box directly over that same object (e.g., `Label(key='animal', value='cat')`), we'd say it's a `misclassification`.
+    - Any false positives that do not meet this criteria are considered to be `hallucinations`.
+    - A **false negative** is determined to be a `misclassification` if the following criteria are met:
+        1. There is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect.
+        2. The qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`.
+    - For false negatives that do not meet this criteria, we consider these datums to have `no_predictions`.
 
 The `DetailedPrecisionRecallOutput` also includes up to `n` examples of each type of error, where `n` is set using `pr_curve_max_examples`. An example output is as follows:
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -226,15 +226,15 @@ Valor also includes a more detailed version of `PrecisionRecallCurve` which can 
         - `no_predictions`: Occurs when no label passes the score threshold.
 
 #### Object Detection Tasks
-    - A **false positive** is a `misclassification` if the following conditions are met:
-        1. There is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect
-        2. The qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`.
-        - For example: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another bounding box directly over that same object (e.g., `Label(key='animal', value='cat')`), we'd say it's a `misclassification`.
-    - Any false positives that do not meet this criteria are considered to be `hallucinations`.
-    - A **false negative** is determined to be a `misclassification` if the following criteria are met:
-        1. There is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect.
-        2. The qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`.
-    - For false negatives that do not meet this criteria, we consider these datums to have `no_predictions`.
+  - A **false positive** is a `misclassification` if the following conditions are met:
+    1. There is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect
+    2. The qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`.
+  - A **false positive** that does not meet the `misclassification` criteria is considered to be a part of the `hallucinations` set.
+  - A **false negative** is determined to be a `misclassification` if the following criteria are met:
+    1. There is a qualified prediction with the same `Label.key` as the groundtruth on the datum, but the `Label.value` is incorrect.
+    2. The qualified prediction and groundtruth have an IOU >= `pr_curve_iou_threshold`.
+  - For a **false negative** that does not meet this criteria, we consider it to have `no_predictions`.
+  - **Example**: if there's a photo with one groundtruth label on it (e.g., `Label(key='animal', value='dog')`), and we predicted another bounding box directly over that same object (e.g., `Label(key='animal', value='cat')`), we'd say it's a `misclassification`.
 
 The `DetailedPrecisionRecallOutput` also includes up to `n` examples of each type of error, where `n` is set using `pr_curve_max_examples`. An example output is as follows:
 

--- a/integration_tests/client/metrics/test_classification.py
+++ b/integration_tests/client/metrics/test_classification.py
@@ -1116,7 +1116,7 @@ def test_evaluate_classification_with_label_maps(
         },
         (0, "v1", "0.1", "tn"): {"all": 2, "total": 2},
         (0, "v1", "0.1", "fn"): {
-            "null_prediction": 0,
+            "no_prediction": 0,
             "misclassifications": 0,
             "total": 0,
         },
@@ -1128,12 +1128,12 @@ def test_evaluate_classification_with_label_maps(
         },
         (1, "v1", "0.1", "tn"): {"all": 2, "total": 2},
         (1, "v1", "0.1", "fn"): {
-            "null_prediction": 0,
+            "no_prediction": 0,
             "misclassifications": 0,
             "total": 0,
         },
         (1, "v4", "0.1", "fn"): {
-            "null_prediction": 0,
+            "no_prediction": 0,
             "misclassifications": 1,
             "total": 1,
         },

--- a/integration_tests/client/metrics/test_classification.py
+++ b/integration_tests/client/metrics/test_classification.py
@@ -1111,31 +1111,29 @@ def test_evaluate_classification_with_label_maps(
         # k3
         (0, "v1", "0.1", "tp"): {"all": 0, "total": 0},
         (0, "v1", "0.1", "fp"): {
-            "hallucinations": 0,
             "misclassifications": 1,
             "total": 1,
         },
         (0, "v1", "0.1", "tn"): {"all": 2, "total": 2},
         (0, "v1", "0.1", "fn"): {
-            "missed_detections": 0,
+            "null_prediction": 0,
             "misclassifications": 0,
             "total": 0,
         },
         # k4
         (1, "v1", "0.1", "tp"): {"all": 0, "total": 0},
         (1, "v1", "0.1", "fp"): {
-            "hallucinations": 0,
             "misclassifications": 1,
             "total": 1,
         },
         (1, "v1", "0.1", "tn"): {"all": 2, "total": 2},
         (1, "v1", "0.1", "fn"): {
-            "missed_detections": 0,
+            "null_prediction": 0,
             "misclassifications": 0,
             "total": 0,
         },
         (1, "v4", "0.1", "fn"): {
-            "missed_detections": 0,
+            "null_prediction": 0,
             "misclassifications": 1,
             "total": 1,
         },

--- a/integration_tests/client/metrics/test_classification.py
+++ b/integration_tests/client/metrics/test_classification.py
@@ -1116,7 +1116,7 @@ def test_evaluate_classification_with_label_maps(
         },
         (0, "v1", "0.1", "tn"): {"all": 2, "total": 2},
         (0, "v1", "0.1", "fn"): {
-            "no_prediction": 0,
+            "no_predictions": 0,
             "misclassifications": 0,
             "total": 0,
         },
@@ -1128,12 +1128,12 @@ def test_evaluate_classification_with_label_maps(
         },
         (1, "v1", "0.1", "tn"): {"all": 2, "total": 2},
         (1, "v1", "0.1", "fn"): {
-            "no_prediction": 0,
+            "no_predictions": 0,
             "misclassifications": 0,
             "total": 0,
         },
         (1, "v4", "0.1", "fn"): {
-            "no_prediction": 0,
+            "no_predictions": 0,
             "misclassifications": 1,
             "total": 1,
         },

--- a/integration_tests/client/metrics/test_detection.py
+++ b/integration_tests/client/metrics/test_detection.py
@@ -1349,7 +1349,7 @@ def test_evaluate_detection_with_label_maps(
             "total": 0,
         },
         (0, "british shorthair", "0.1", "fn"): {
-            "missed_detections": 1,
+            "no_predictions": 1,
             "misclassifications": 0,
             "total": 1,
         },
@@ -1360,25 +1360,25 @@ def test_evaluate_detection_with_label_maps(
             "total": 1,
         },
         (1, "maine coon cat", "0.1", "fn"): {
-            "missed_detections": 1,
+            "no_predictions": 1,
             "misclassifications": 0,
             "total": 1,
         },
         # k1
         (2, "v1", "0.1", "fn"): {
-            "missed_detections": 1,
+            "no_predictions": 1,
             "misclassifications": 0,
             "total": 1,
         },
         (2, "v1", "0.4", "fn"): {
-            "missed_detections": 2,
+            "no_predictions": 2,
             "misclassifications": 0,
             "total": 2,
         },
         (2, "v1", "0.1", "tp"): {"all": 1, "total": 1},
         # k2
         (3, "v2", "0.1", "fn"): {
-            "missed_detections": 1,
+            "no_predictions": 1,
             "misclassifications": 0,
             "total": 1,
         },
@@ -1423,7 +1423,7 @@ def test_evaluate_detection_with_label_maps(
     )
     assert (
         len(
-            detailed_pr_metrics[2]["value"]["v1"]["0.4"]["fn"]["observations"]["missed_detections"][  # type: ignore - we know this element is a dict
+            detailed_pr_metrics[2]["value"]["v1"]["0.4"]["fn"]["observations"]["no_predictions"][  # type: ignore - we know this element is a dict
                 "examples"
             ]
         )
@@ -2669,7 +2669,7 @@ def test_detailed_precision_recall_curve(
     assert eval_job.metrics[0]["value"]["v1"]["0.55"]["fn"]["total"] == 1
     assert (
         eval_job.metrics[0]["value"]["v1"]["0.55"]["fn"]["observations"][
-            "missed_detections"
+            "no_predictions"
         ]["count"]
         == 1
     )
@@ -2680,13 +2680,13 @@ def test_detailed_precision_recall_curve(
     assert (
         eval_job.metrics[0]["value"]["missed_detection"]["0.05"]["fn"][
             "observations"
-        ]["missed_detections"]["count"]
+        ]["no_predictions"]["count"]
         == 1
     )
     assert (
         eval_job.metrics[0]["value"]["missed_detection"]["0.95"]["fn"][
             "observations"
-        ]["missed_detections"]["count"]
+        ]["no_predictions"]["count"]
         == 1
     )
     assert (
@@ -2701,13 +2701,13 @@ def test_detailed_precision_recall_curve(
     # one fn missed_dection that becomes a misclassification when pr_curve_iou_threshold <= .48 and score threshold <= .3
     assert (
         eval_job.metrics[0]["value"]["v2"]["0.3"]["fn"]["observations"][
-            "missed_detections"
+            "no_predictions"
         ]["count"]
         == 1
     )
     assert (
         eval_job.metrics[0]["value"]["v2"]["0.35"]["fn"]["observations"][
-            "missed_detections"
+            "no_predictions"
         ]["count"]
         == 1
     )
@@ -2755,13 +2755,13 @@ def test_detailed_precision_recall_curve(
     # one missed detection and one hallucination due to low iou overlap
     assert (
         eval_job.metrics[0]["value"]["low_iou"]["0.3"]["fn"]["observations"][
-            "missed_detections"
+            "no_predictions"
         ]["count"]
         == 1
     )
     assert (
         eval_job.metrics[0]["value"]["low_iou"]["0.95"]["fn"]["observations"][
-            "missed_detections"
+            "no_predictions"
         ]["count"]
         == 1
     )
@@ -2795,7 +2795,7 @@ def test_detailed_precision_recall_curve(
     assert eval_job.metrics[0]["value"]["v1"]["0.55"]["fn"]["total"] == 1
     assert (
         eval_job.metrics[0]["value"]["v1"]["0.55"]["fn"]["observations"][
-            "missed_detections"
+            "no_predictions"
         ]["count"]
         == 1
     )
@@ -2806,13 +2806,13 @@ def test_detailed_precision_recall_curve(
     assert (
         eval_job.metrics[0]["value"]["missed_detection"]["0.05"]["fn"][
             "observations"
-        ]["missed_detections"]["count"]
+        ]["no_predictions"]["count"]
         == 1
     )
     assert (
         eval_job.metrics[0]["value"]["missed_detection"]["0.95"]["fn"][
             "observations"
-        ]["missed_detections"]["count"]
+        ]["no_predictions"]["count"]
         == 1
     )
     assert (
@@ -2834,7 +2834,7 @@ def test_detailed_precision_recall_curve(
     assert (
         eval_job_low_iou_threshold.metrics[0]["value"]["v2"]["0.3"]["fn"][
             "observations"
-        ]["missed_detections"]["count"]
+        ]["no_predictions"]["count"]
         == 0
     )
     assert (
@@ -2846,7 +2846,7 @@ def test_detailed_precision_recall_curve(
     assert (
         eval_job_low_iou_threshold.metrics[0]["value"]["v2"]["0.35"]["fn"][
             "observations"
-        ]["missed_detections"]["count"]
+        ]["no_predictions"]["count"]
         == 1
     )
     assert (
@@ -2913,13 +2913,13 @@ def test_detailed_precision_recall_curve(
     # one missed detection and one hallucination due to low iou overlap
     assert (
         eval_job.metrics[0]["value"]["low_iou"]["0.3"]["fn"]["observations"][
-            "missed_detections"
+            "no_predictions"
         ]["count"]
         == 1
     )
     assert (
         eval_job.metrics[0]["value"]["low_iou"]["0.95"]["fn"]["observations"][
-            "missed_detections"
+            "no_predictions"
         ]["count"]
         == 1
     )


### PR DESCRIPTION
# COPY OF #650 

### Problem Description

The pr curve documentation specifies the following definitions for False-Positive and False-Negative results.

> A false positive is a misclassification if there is a qualified prediction (with score >= score_threshold) with the same Label.key as the groundtruth on the datum, but the Label.value is incorrect. For example: if there's a photo with one groundtruth label on it (e.g., Label(key='animal', value='dog')), and we predicted another label value (e.g., Label(key='animal', value='cat')) on that datum, we'd say it's a misclassification since the key was correct but the value was not. Any false positives that do not meet this criteria are considered to be hallucinations.
Similarly, a false negative is a misclassification if there is a prediction with the same Label.key as the groundtruth on the datum, but the Label.value is incorrect. Any false negatives that do not meet this criteria are considered to be missed_detections.

- **False Positive misclassifications** are clearly defined as predictions passing a score threshold that share a matching label key and value with the ground truth.
- **False Positive hallucinations** are defined as any false-positives that don't match the criteria for FP misclassification. As a score lower than the threshold would render it a FN or TN we are left with determining that a hallucination can only occur when either the label key or label value do not match which would also render it a FN or TN.
- **False Negative misclassifications** is defined as a prediction that has a matching label key but mismatched label value. This does not account for score which is typically required to determine a FN. 
- **False Negative missing detections** are defined as FN that do not meet the misclassification criteria. Since score threshold is not mentioned in determining false negatives it seems that a missing detection is defined by the same contradictory condition that exists for hallucinations.

### Feature Description

Redefine the variants of FP an FN

- **False Positive misclassification** would be defined as a prediction that met a score threshold but did not containing a matching label value for a shared key.
- **False Positive hallucination** will be removed. The only time a model can hallucinate is if it has access to labels that the dataset does not. This condition is impossible as we validate that datasets and models contain matching label sets.
- **False Negative misclassification** is defined as a prediction where the wrong label met the score threshold.
- **False Negative "no prediction"** is defined as a prediction in which no label met the score threshold.

These changes to the definitions would require no change to the existing backend and not change any tests beyond removing hallucination = 0.
