### PR TITLE
Integration Test Failing due to Unordered List

### DIFF
--- a/integration_tests/client/datasets/test_dataset.py
+++ b/integration_tests/client/datasets/test_dataset.py
@@ -272,17 +272,13 @@ def test_create_tabular_dataset_and_add_groundtruth(
     assert set(d.uid for d in data) == {"uid1", "uid2"}
 
     # check metadata is there
-    metadata_links = data[0].meta
-    assert len(metadata_links) == 1
-    assert "metadatum1" in metadata_links
-    assert metadata_links["metadatum1"] == "temporary"
-
-    metadata_links = data[1].meta
-    assert len(metadata_links) == 2
-    assert "metadatum2" in metadata_links
-    assert metadata_links["metadatum2"] == "a string"
-    assert "metadatum3" in metadata_links
-    assert metadata_links["metadatum3"] == 0.45
+    for datum in data:
+        if "metadatum1" in datum.meta:
+            assert len(datum.meta) == 1
+            assert datum.meta == md1
+        elif "metadatum2" in datum.meta and "metadatum3" in datum.meta:
+            assert len(datum.meta) == 2
+            assert datum.meta == md23
 
     # check that we can add data with specified uids
     new_gts = [

--- a/integration_tests/client/datasets/test_dataset.py
+++ b/integration_tests/client/datasets/test_dataset.py
@@ -279,6 +279,8 @@ def test_create_tabular_dataset_and_add_groundtruth(
         elif "metadatum2" in datum.meta and "metadatum3" in datum.meta:
             assert len(datum.meta) == 2
             assert datum.meta == md23
+        else:
+            assert False
 
     # check that we can add data with specified uids
     new_gts = [


### PR DESCRIPTION

### Reproducible Example

```python
`integration_tests/client/datasets/test_dataset.py::test_create_tabular_dataset_and_add_groundtruth`
```


### Issue Description

The test queries from postgres and treats the response as an ordered list which it is not.

Test failure is dependent on what order postgres returns its response.

### Expected Behavior

The test should not assume an ordered response from postgres.