### PR TITLE
fix benchmark typo

### DIFF
--- a/integration_tests/benchmarks/classification/benchmark_script.py
+++ b/integration_tests/benchmarks/classification/benchmark_script.py
@@ -105,11 +105,8 @@ def ingest_groundtruths_and_predictions(
             )
         )
 
-    for gt in groundtruths:
-        dset.add_groundtruth(gt)
-
-    for pred in predictions:
-        model.add_prediction(dset, pred)
+    dset.add_groundtruths(groundtruths, timeout=15)
+    model.add_predictions(dset, predictions, timeout=15)
 
     dset.finalize()
     model.finalize_inferences(dataset=dset)
@@ -198,7 +195,7 @@ def run_benchmarking_analysis(
         results = {
             "number_of_datums": limit,
             "number_of_unique_labels": eval_.meta["labels"],
-            "number_of_annotations": eval_.meta["labels"],
+            "number_of_annotations": eval_.meta["annotations"],
             "ingest_runtime": f"{(ingest_time):.1f} seconds",
             "eval_runtime": f"{(eval_.meta['duration']):.1f} seconds",
         }

--- a/integration_tests/benchmarks/object-detection/benchmark_script.py
+++ b/integration_tests/benchmarks/object-detection/benchmark_script.py
@@ -275,7 +275,7 @@ def run_benchmarking_analysis(
         results = {
             "number_of_datums": limit,
             "number_of_unique_labels": eval_.meta["labels"],
-            "number_of_annotations": eval_.meta["labels"],
+            "number_of_annotations": eval_.meta["annotations"],
             "ingest_runtime": f"{(ingest_time):.1f} seconds",
             "eval_runtime": f"{(eval_.meta['duration']):.1f} seconds",
         }


### PR DESCRIPTION
### Issue Description

```python
results = {
            "number_of_datums": limit,
            "number_of_unique_labels": eval_.meta["labels"],
            "number_of_annotations": eval_.meta["labels"],  # this should be annotations
            "ingest_runtime": f"{(ingest_time):.1f} seconds",
            "eval_runtime": f"{(eval_.meta['duration']):.1f} seconds",
        }
```