### PR TITLE
Allow Retrying of Deletion

### DIFF
--- a/api/valor_api/backend/core/model.py
+++ b/api/valor_api/backend/core/model.py
@@ -377,21 +377,24 @@ def delete_model(
     name : str
         The name of the model.
     """
-    model = fetch_model(db, name=name)
+    if core.count_active_evaluations(db=db, model_names=[name]):
+        raise exceptions.EvaluationRunningError(model_name=name)
 
-    # set status
+    model = (
+        db.query(models.Model).where(models.Model.name == name).one_or_none()
+    )
+    if not model:
+        raise exceptions.ModelDoesNotExistError(name)
+
     try:
+        # set status
         model.status = ModelStatus.DELETING
         db.commit()
-    except Exception as e:
-        db.rollback()
-        raise e
 
-    core.delete_evaluations(db=db, model_names=[name])
-    core.delete_model_predictions(db=db, model=model)
-    core.delete_model_annotations(db=db, model=model)
+        core.delete_evaluations(db=db, model_names=[name])
+        core.delete_model_predictions(db=db, model=model)
+        core.delete_model_annotations(db=db, model=model)
 
-    try:
         db.execute(delete(models.Model).where(models.Model.id == model.id))
         db.commit()
     except IntegrityError as e:


### PR DESCRIPTION
### Problem Description

If a deletion job gets cancelled or hits its timeout then an zombie row can be created.

This occurs as the existing dataset and model deletion functions rely on getter/setter functions that filter out rows with `DELETING` states.

From the user perspective this produces a very frustrating response where you get `DatasetAlreadyExistsError` when creating a dataset and `DatasetDoesNotExistError` when you try to delete it. 

### Feature Description

Remove reliance on external getter/setter functions in dataset and model deletion methods so that they can be run repeatedly.