### PR TITLE
Fix code coverage with external tests

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -66,11 +66,11 @@ jobs:
         run: pip install -e ".[test]"
         working-directory: ./client
       - name: run integration tests
-        run: coverage run --source="api/valor_api,client/valor" -m pytest -v integration_tests/client/*
+        run: coverage run -a --source="api/valor_api,client/valor" -m pytest -v integration_tests/client/*
       - name: run external integration tests
         run: |
-          if ${{ github.ref == 'refs/heads/add_remaining_RAG_metrics' }}; then
-            coverage run --source="api/valor_api,client/valor" -m pytest -v integration_tests/external/*
+          if ${{ github.ref == 'refs/heads/fix_code_coverage_with_external_tests' }}; then
+            coverage run -a --source="api/valor_api,client/valor" -m pytest -v integration_tests/external/*
           fi
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -69,7 +69,7 @@ jobs:
         run: coverage run --source="api/valor_api,client/valor" -m pytest -v integration_tests/client/*
       - name: run external integration tests
         run: |
-          if ${{ github.ref == 'refs/heads/main' }}; then
+          if ${{ github.ref == 'refs/heads/add_remaining_RAG_metrics' }}; then
             coverage run --source="api/valor_api,client/valor" -m pytest -v integration_tests/external/*
           fi
         env:

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -69,7 +69,7 @@ jobs:
         run: coverage run -a --source="api/valor_api,client/valor" -m pytest -v integration_tests/client/*
       - name: run external integration tests
         run: |
-          if ${{ github.ref == 'refs/heads/fix_code_coverage_with_external_tests' }}; then
+          if ${{ github.ref == 'refs/heads/main' }}; then
             coverage run -a --source="api/valor_api,client/valor" -m pytest -v integration_tests/external/*
           fi
         env:


### PR DESCRIPTION
Fix an issue where the external integration tests code coverage overwrites the regular integration tests code coverage. 