### PR TITLE
increase obj det benchmark timeout to 90

### DIFF
--- a/integration_tests/benchmarks/object-detection/benchmark_script.py
+++ b/integration_tests/benchmarks/object-detection/benchmark_script.py
@@ -190,7 +190,7 @@ def ingest_groundtruths_and_predictions(
 def run_base_evaluation(dset: Dataset, model: Model):
     """Run a base evaluation (with no PR curves)."""
     evaluation = model.evaluate_detection(dset)
-    evaluation.wait_for_completion(timeout=60)
+    evaluation.wait_for_completion(timeout=90)
     return evaluation
 
 


### PR DESCRIPTION
The object detection benchmark passes inconsistently with a timeout of 60. Increasing the timeout to 90 causes the benchmark to pass consistently. Below I screenshotted the benchmark passing on all 5 attempts with the timeout set to 90. 
![passing benchmark](https://github.com/user-attachments/assets/96b6ad1f-e62d-48cf-8e43-1d990eec6671)
