### PR TITLE
adjusted iou computation

### DIFF
--- a/api/valor_api/backend/core/annotation.py
+++ b/api/valor_api/backend/core/annotation.py
@@ -1,5 +1,5 @@
 from geoalchemy2.functions import ST_AsGeoJSON
-from sqlalchemy import ScalarSelect, and_, delete, insert, select
+from sqlalchemy import ScalarSelect, and_, delete, insert, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -364,6 +364,17 @@ def delete_dataset_annotations(
             .where(models.Datum.dataset_id == dataset.id)
             .subquery()
         )
+
+        db.execute(
+            delete(models.IoU).where(
+                or_(
+                    models.IoU.groundtruth_annotation_id
+                    == annotations_to_delete.c.id,
+                    models.IoU.prediction_annotation_id
+                    == annotations_to_delete.c.id,
+                )
+            )
+        )
         db.execute(
             delete(models.Annotation).where(
                 models.Annotation.id == annotations_to_delete.c.id
@@ -417,6 +428,16 @@ def delete_model_annotations(
             select(models.Annotation)
             .where(models.Annotation.model_id == model.id)
             .subquery()
+        )
+        db.execute(
+            delete(models.IoU).where(
+                or_(
+                    models.IoU.groundtruth_annotation_id
+                    == annotations_to_delete.c.id,
+                    models.IoU.prediction_annotation_id
+                    == annotations_to_delete.c.id,
+                )
+            )
         )
         db.execute(
             delete(models.Annotation).where(

--- a/api/valor_api/backend/models.py
+++ b/api/valor_api/backend/models.py
@@ -148,6 +148,14 @@ class Annotation(Base):
     predictions: Mapped[list["Prediction"]] = relationship(
         cascade="all, delete-orphan"
     )
+    groundtruth_ious: Mapped[list["IoU"]] = relationship(
+        foreign_keys="IoU.groundtruth_annotation_id",
+        cascade="all, delete-orphan",
+    )
+    prediction_ious: Mapped[list["IoU"]] = relationship(
+        foreign_keys="IoU.prediction_annotation_id",
+        cascade="all, delete-orphan",
+    )
 
 
 class Datum(Base):
@@ -265,4 +273,38 @@ class ConfusionMatrix(Base):
     # relationships
     settings: Mapped[Evaluation] = relationship(
         back_populates="confusion_matrices"
+    )
+
+
+class IoU(Base):
+    __tablename__ = "iou"
+    __table_args__ = (
+        UniqueConstraint(
+            "groundtruth_annotation_id",
+            "prediction_annotation_id",
+            "type",
+        ),
+    )
+
+    # columns
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    groundtruth_annotation_id: Mapped[int] = mapped_column(
+        ForeignKey("annotation.id"), nullable=False
+    )
+    prediction_annotation_id: Mapped[int] = mapped_column(
+        ForeignKey("annotation.id"), nullable=False
+    )
+    iou: Mapped[float] = mapped_column(nullable=False)
+    type: Mapped[str] = mapped_column(nullable=False)
+
+    # relationships
+    groundtruth = relationship(
+        "Annotation",
+        foreign_keys=[groundtruth_annotation_id],
+        back_populates="groundtruth_ious",
+    )
+    prediction = relationship(
+        "Annotation",
+        foreign_keys=[prediction_annotation_id],
+        back_populates="prediction_ious",
     )

--- a/api/valor_api/backend/models.py
+++ b/api/valor_api/backend/models.py
@@ -296,6 +296,7 @@ class IoU(Base):
     )
     iou: Mapped[float] = mapped_column(nullable=False)
     type: Mapped[str] = mapped_column(nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(default=func.now())
 
     # relationships
     groundtruth = relationship(

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker.io/migrate/migrate
+RUN apk upgrade && apk update
 COPY . /migrations
 WORKDIR /migrations
 

--- a/migrations/sql/00000013_iou_cache.down.sql
+++ b/migrations/sql/00000013_iou_cache.down.sql
@@ -1,0 +1,1 @@
+drop table iou cascade;

--- a/migrations/sql/00000013_iou_cache.up.sql
+++ b/migrations/sql/00000013_iou_cache.up.sql
@@ -1,0 +1,12 @@
+create table iou
+(
+    id serial primary key,
+    groundtruth_annotation_id integer not null references annotation,
+    prediction_annotation_id integer not null references annotation,
+    type varchar not null,
+    iou double precision not null,
+    unique (groundtruth_annotation_id, prediction_annotation_id, type)
+);
+
+create index ix_iou_id
+    on iou (id);

--- a/migrations/sql/00000013_iou_cache.up.sql
+++ b/migrations/sql/00000013_iou_cache.up.sql
@@ -6,6 +6,7 @@ create table iou
     type varchar not null,
     iou double precision not null,
     unique (groundtruth_annotation_id, prediction_annotation_id, type)
+    created_at timestamp not null,
 );
 
 create index ix_iou_id


### PR DESCRIPTION
Attempting to fix intermittent slowdowns in object detection benchmark.

# Changes
- Added `.isnot(None)` clause to ensure that only annotations with the requested type are included.
- Caching results of IoU computation in a table.