### PR TITLE
don't allow commas in model and dataset names

### DIFF
--- a/api/tests/unit-tests/schemas/test_core.py
+++ b/api/tests/unit-tests/schemas/test_core.py
@@ -66,6 +66,10 @@ def test_dataset(metadata):
             metadata=[{123: 12434}, "123"],  # type: ignore - purposefully throwing error
         )
 
+    with pytest.raises(ValidationError) as exc_info:
+        schemas.Dataset(name="name,with,commas")
+    assert "cannot contain commas" in str(exc_info)
+
 
 def test_model(metadata):
     # valid
@@ -110,6 +114,10 @@ def test_model(metadata):
             name="123",
             metadata=[{123: 12434}, "123"],  # type: ignore - purposefully throwing error
         )
+
+    with pytest.raises(ValidationError) as exc_info:
+        schemas.Model(name="name,with,commas")
+    assert "cannot contain commas" in str(exc_info)
 
 
 def test_datum(metadata):

--- a/api/valor_api/schemas/types.py
+++ b/api/valor_api/schemas/types.py
@@ -551,6 +551,14 @@ class Dataset(BaseModel):
         validate_metadata(v)
         return v
 
+    @field_validator("name")
+    @classmethod
+    def validate_name_no_commans(cls, v: str) -> str:
+        """Validates the 'name' field has no commas in it."""
+        if "," in v:
+            raise ValueError("Dataset names cannot contain commas.")
+        return v
+
 
 class Model(BaseModel):
     """
@@ -573,6 +581,14 @@ class Model(BaseModel):
     def validate_name(cls, v: str) -> str:
         """Validates the 'name' field."""
         validate_type_string(v)
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def validate_name_no_commans(cls, v: str) -> str:
+        """Validates the 'name' field has no commas in it."""
+        if "," in v:
+            raise ValueError("Model names cannot contain commas.")
         return v
 
     @field_validator("metadata")

--- a/migrations/sql/00000013_disallow_commas.sql
+++ b/migrations/sql/00000013_disallow_commas.sql
@@ -1,0 +1,66 @@
+-- this migration goes  through dataset names and model names and replaces commas with underscores
+-- if the resulting name happens to exist, it adds underscores until it gets a name that doesn't
+-- this will update the following tables: Model, Dataset, Evaluation
+BEGIN;
+
+-- Function to get a unique name by adding underscores
+CREATE OR REPLACE FUNCTION get_unique_name(base_name TEXT, table_name TEXT)
+RETURNS TEXT AS $$
+DECLARE
+    unique_name TEXT := base_name;
+    name_exists INT;
+BEGIN
+    EXECUTE format('SELECT COUNT(*) FROM %I WHERE name = $1', table_name) INTO name_exists USING unique_name;
+
+    WHILE name_exists > 0 LOOP
+        unique_name := unique_name || '_';
+        EXECUTE format('SELECT COUNT(*) FROM %I WHERE name = $1', table_name) INTO name_exists USING unique_name;
+    END LOOP;
+
+    RETURN unique_name;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+DECLARE
+    old_name TEXT;
+    new_name TEXT;
+BEGIN
+    FOR old_name IN SELECT name FROM model WHERE POSITION(',' IN name) > 0 LOOP
+        new_name := get_unique_name(REPLACE(old_name, ',', '_'), 'model');
+
+        UPDATE Model SET name = new_name WHERE name = old_name;
+
+        UPDATE Evaluation SET model_name = new_name WHERE model_name = old_name;
+    END LOOP;
+END;
+$$;
+
+DO $$
+DECLARE
+    old_name TEXT;
+    new_name TEXT;
+BEGIN
+    FOR old_name IN SELECT name FROM Dataset WHERE POSITION(',' IN name) > 0 LOOP
+        new_name := get_unique_name(REPLACE(old_name, ',', '_'), 'dataset');
+
+        UPDATE Dataset SET name = new_name WHERE name = old_name;
+
+        UPDATE Evaluation
+        SET dataset_names = (
+            SELECT jsonb_agg(
+                CASE
+                    WHEN elem = old_name THEN new_name
+                    ELSE elem
+                END
+            )
+            FROM jsonb_array_elements_text(dataset_names) AS elem
+        )
+        WHERE dataset_names @> jsonb_build_array(old_name);
+    END LOOP;
+END;
+$$;
+
+DROP FUNCTION get_unique_name;
+
+COMMIT;

--- a/migrations/sql/00000013_disallow_commas.up.sql
+++ b/migrations/sql/00000013_disallow_commas.up.sql
@@ -1,7 +1,6 @@
 -- this migration goes  through dataset names and model names and replaces commas with underscores
 -- if the resulting name happens to exist, it adds underscores until it gets a name that doesn't
 -- this will update the following tables: Model, Dataset, Evaluation
-BEGIN;
 
 -- Function to get a unique name by adding underscores
 CREATE OR REPLACE FUNCTION get_unique_name(base_name TEXT, table_name TEXT)
@@ -62,5 +61,3 @@ END;
 $$;
 
 DROP FUNCTION get_unique_name;
-
-COMMIT;


### PR DESCRIPTION
this was causing things like `get_evaluations` to fail since the query params are string separated model names