### PR TITLE
Add test for mixed-type dataset concatenation.

### DIFF
--- a/api/valor_api/backend/metrics/detection.py
+++ b/api/valor_api/backend/metrics/detection.py
@@ -787,6 +787,8 @@ def _convert_annotations_to_common_type(
         source_type = core.get_annotation_type(
             db=db, dataset=dataset, task_type=enums.TaskType.OBJECT_DETECTION
         )
+        if target_type > source_type:
+            continue
         core.convert_geometry(
             db=db,
             dataset=dataset,


### PR DESCRIPTION
# Changes
- Added a test that concatenates object detection datasets with different annotation types.
- Fixed a bug in backend that wouldn't allow forcing of annotation type. Annotations that cannot meet the forced type are not included in the evaluation.