### PR TITLE
Raise ValueError if Annotation does not Support Target Type

### DIFF
--- a/api/valor_api/backend/metrics/detection.py
+++ b/api/valor_api/backend/metrics/detection.py
@@ -788,7 +788,9 @@ def _convert_annotations_to_common_type(
             db=db, dataset=dataset, task_type=enums.TaskType.OBJECT_DETECTION
         )
         if target_type > source_type:
-            continue
+            raise ValueError(
+                f"Cannot convert dataset {dataset.name} annotations from {source_type} to {target_type}."
+            )
         core.convert_geometry(
             db=db,
             dataset=dataset,
@@ -803,6 +805,10 @@ def _convert_annotations_to_common_type(
             model=model,
             task_type=enums.TaskType.OBJECT_DETECTION,
         )
+        if target_type > source_type:
+            raise ValueError(
+                f"Cannot convert model {model.name} annotations from {source_type} to {target_type}."
+            )
         core.convert_geometry(
             db=db,
             dataset=dataset,

--- a/integration_tests/client/metrics/test_detection.py
+++ b/integration_tests/client/metrics/test_detection.py
@@ -3454,80 +3454,6 @@ def test_evaluate_mixed_annotations(
     for m in expected:
         assert m in eval_job.metrics
 
-    eval_job_raster = model.evaluate_detection(
-        [dset_box, dset_polygon, dset_raster],
-        iou_thresholds_to_compute=[0.1, 0.6],
-        iou_thresholds_to_return=[0.1, 0.6],
-        metrics_to_return=[
-            "AP",
-        ],
-        convert_annotations_to_type=AnnotationType.RASTER,
-    )
-    eval_job_raster.wait_for_completion()
-
-    expected = [
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.1},
-            "value": 1.0,
-            "label": {"key": "raster", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.6},
-            "value": 1.0,
-            "label": {"key": "raster", "value": "value"},
-        },
-    ]
-
-    for m in eval_job_raster.metrics:
-        assert m in expected
-    for m in expected:
-        assert m in eval_job_raster.metrics
-
-    eval_job_poly = model.evaluate_detection(
-        [dset_box, dset_polygon, dset_raster],
-        iou_thresholds_to_compute=[0.1, 0.6],
-        iou_thresholds_to_return=[0.1, 0.6],
-        metrics_to_return=[
-            "AP",
-        ],
-        convert_annotations_to_type=AnnotationType.POLYGON,
-    )
-    eval_job_poly.wait_for_completion()
-
-    expected = [
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.1},
-            "value": 1.0,
-            "label": {"key": "raster", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.6},
-            "value": 1.0,
-            "label": {"key": "raster", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.1},
-            "value": 1.0,
-            "label": {"key": "polygon", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.6},
-            "value": 1.0,
-            "label": {"key": "polygon", "value": "value"},
-        },
-    ]
-
-    for m in eval_job_poly.metrics:
-        assert m in expected
-    for m in expected:
-        assert m in eval_job_poly.metrics
-
     eval_job_box = model.evaluate_detection(
         [dset_box, dset_polygon, dset_raster],
         iou_thresholds_to_compute=[0.1, 0.6],
@@ -3539,46 +3465,33 @@ def test_evaluate_mixed_annotations(
     )
     eval_job_box.wait_for_completion()
 
-    expected = [
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.1},
-            "value": 1.0,
-            "label": {"key": "raster", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.6},
-            "value": 1.0,
-            "label": {"key": "raster", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.1},
-            "value": 1.0,
-            "label": {"key": "box", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.6},
-            "value": 1.0,
-            "label": {"key": "box", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.1},
-            "value": 1.0,
-            "label": {"key": "polygon", "value": "value"},
-        },
-        {
-            "type": "AP",
-            "parameters": {"iou": 0.6},
-            "value": 1.0,
-            "label": {"key": "polygon", "value": "value"},
-        },
-    ]
-
     for m in eval_job_box.metrics:
         assert m in expected
     for m in expected:
         assert m in eval_job_box.metrics
+
+    # cannot force to polygon as some datasets do not contain this type
+    eval_job_poly = model.evaluate_detection(
+        [dset_box, dset_polygon, dset_raster],
+        iou_thresholds_to_compute=[0.1, 0.6],
+        iou_thresholds_to_return=[0.1, 0.6],
+        metrics_to_return=[
+            "AP",
+        ],
+        convert_annotations_to_type=AnnotationType.POLYGON,
+    )
+    eval_job_poly.wait_for_completion()
+    assert eval_job_poly.status == EvaluationStatus.FAILED
+
+    # cannot force to raster as some datasets do not contain this type
+    eval_job_raster = model.evaluate_detection(
+        [dset_box, dset_polygon, dset_raster],
+        iou_thresholds_to_compute=[0.1, 0.6],
+        iou_thresholds_to_return=[0.1, 0.6],
+        metrics_to_return=[
+            "AP",
+        ],
+        convert_annotations_to_type=AnnotationType.RASTER,
+    )
+    eval_job_raster.wait_for_completion()
+    assert eval_job_raster.status == EvaluationStatus.FAILED


### PR DESCRIPTION
# Changes
- If a conversion is forced in object detection, the underlying data must now support it. Otherwise, a `ValueError` is raised and the evaluation fails.