### PR TITLE
Fix bug when assigning "no prediction" false negative flags

### DIFF
--- a/core/valor_core/classification.py
+++ b/core/valor_core/classification.py
@@ -810,11 +810,11 @@ def _calculate_pr_curves(
             confidence_interval_to_misclassification_fn_groundtruth_ids_dict.items()
         ):
             threshold_mask = pr_calc_df["confidence_threshold"] == threshold
-            membership_mask = ~pr_calc_df["id_gt"].isin(elements)
+            membership_mask = pr_calc_df["id_gt"].isin(elements)
             mask |= threshold_mask & membership_mask
 
         pr_calc_df["no_predictions_false_negative_flag"] = (
-            mask & pr_calc_df["false_negative_flag"]
+            ~mask & pr_calc_df["false_negative_flag"]
         )
 
     else:


### PR DESCRIPTION
## Improvements
- Fix a bug Justin found where "no prediction" false negative flags were not being correctly flagged in `_calculate_pr_curves`
- Add tests to validate expected behavior