### PR TITLE
Fix OD benchmarks and disallow calculating DetailedPRCurves when using AnnotationType.RASTER

### DIFF
--- a/core/benchmarks/object-detection/benchmark_script.py
+++ b/core/benchmarks/object-detection/benchmark_script.py
@@ -466,6 +466,7 @@ if __name__ == "__main__":
             (AnnotationType.BOX, AnnotationType.BOX),
         ],
         limits_to_test=[5000, 5000],
+        compute_detailed=False,
     )
 
     # run polygon benchmark
@@ -474,6 +475,7 @@ if __name__ == "__main__":
             (AnnotationType.POLYGON, AnnotationType.POLYGON),
         ],
         limits_to_test=[5000, 5000],
+        compute_detailed=False,
     )
     # run raster benchmark
     run_benchmarking_analysis(

--- a/core/benchmarks/object-detection/benchmark_script.py
+++ b/core/benchmarks/object-detection/benchmark_script.py
@@ -21,6 +21,7 @@ from valor_core import (
     Polygon,
     Prediction,
     Raster,
+    ValorDetectionManager,
     enums,
     evaluate_detection,
 )
@@ -235,9 +236,57 @@ def run_detailed_pr_curve_evaluation(groundtruths, predictions):
             enums.MetricType.mAR,
             enums.MetricType.mAPAveragedOverIOUs,
             enums.MetricType.PrecisionRecallCurve,
+            enums.MetricType.DetailedPrecisionRecallCurve,
         ],
     )
     return evaluation
+
+
+def run_base_evaluation_with_manager(groundtruths, predictions):
+    """Run a base evaluation (with no PR curves) using ValorDetectionManager."""
+    manager = ValorDetectionManager()
+    manager.add_data(groundtruths=groundtruths, predictions=predictions)
+    return manager.evaluate()
+
+
+def run_pr_curve_evaluation_with_manager(groundtruths, predictions):
+    """Run a base evaluation with PrecisionRecallCurve included using ValorDetectionManager."""
+    manager = ValorDetectionManager(
+        metrics_to_return=[
+            enums.MetricType.AP,
+            enums.MetricType.AR,
+            enums.MetricType.mAP,
+            enums.MetricType.APAveragedOverIOUs,
+            enums.MetricType.mAR,
+            enums.MetricType.mAPAveragedOverIOUs,
+            enums.MetricType.PrecisionRecallCurve,
+        ],
+    )
+
+    manager.add_data(groundtruths=groundtruths, predictions=predictions)
+
+    return manager.evaluate()
+
+
+def run_detailed_pr_curve_evaluation_with_manager(groundtruths, predictions):
+    """Run a base evaluation with PrecisionRecallCurve and DetailedPrecisionRecallCurve included using ValorDetectionManager."""
+
+    manager = ValorDetectionManager(
+        metrics_to_return=[
+            enums.MetricType.AP,
+            enums.MetricType.AR,
+            enums.MetricType.mAP,
+            enums.MetricType.APAveragedOverIOUs,
+            enums.MetricType.mAR,
+            enums.MetricType.mAPAveragedOverIOUs,
+            enums.MetricType.PrecisionRecallCurve,
+            enums.MetricType.DetailedPrecisionRecallCurve,
+        ],
+    )
+
+    manager.add_data(groundtruths=groundtruths, predictions=predictions)
+
+    return manager.evaluate()
 
 
 @dataclass
@@ -364,9 +413,13 @@ def run_benchmarking_analysis(
             # run evaluations
             eval_pr = None
             eval_detail = None
-            eval_base = run_base_evaluation(groundtruths, predictions)
+            eval_base = run_base_evaluation_with_manager(
+                groundtruths, predictions
+            )
             if compute_pr:
-                eval_pr = run_pr_curve_evaluation(groundtruths, predictions)
+                eval_pr = run_pr_curve_evaluation_with_manager(
+                    groundtruths, predictions
+                )
             if compute_detailed:
                 eval_detail = run_detailed_pr_curve_evaluation(
                     groundtruths, predictions
@@ -422,11 +475,11 @@ if __name__ == "__main__":
         ],
         limits_to_test=[5000, 5000],
     )
-
     # run raster benchmark
     run_benchmarking_analysis(
         combinations=[
             (AnnotationType.RASTER, AnnotationType.RASTER),
         ],
-        limits_to_test=[500, 500],
+        limits_to_test=[500],
+        compute_detailed=False,
     )

--- a/core/benchmarks/object-detection/benchmark_script.py
+++ b/core/benchmarks/object-detection/benchmark_script.py
@@ -482,6 +482,6 @@ if __name__ == "__main__":
         combinations=[
             (AnnotationType.RASTER, AnnotationType.RASTER),
         ],
-        limits_to_test=[500],
+        limits_to_test=[500, 500],
         compute_detailed=False,
     )

--- a/core/tests/functional-tests/test_detection.py
+++ b/core/tests/functional-tests/test_detection.py
@@ -1223,6 +1223,16 @@ def test_evaluate_detection_functional_test_with_rasters(
             pr_metrics[0]["value"][value][threshold][metric] == expected_value
         )
 
+    # test that we get a NotImplementedError if we try to calculate DetailedPRCurves with rasters
+    with pytest.raises(NotImplementedError):
+        evaluate_detection(
+            groundtruths=evaluate_detection_functional_test_groundtruths_with_rasters,
+            predictions=evaluate_detection_functional_test_predictions_with_rasters,
+            metrics_to_return=[
+                enums.MetricType.DetailedPrecisionRecallCurve,
+            ],
+        )
+
 
 def test_evaluate_mixed_annotations(
     evaluate_mixed_annotations_inputs: tuple,

--- a/core/tests/functional-tests/test_detection_manager.py
+++ b/core/tests/functional-tests/test_detection_manager.py
@@ -1002,6 +1002,21 @@ def test_evaluate_detection_functional_test_with_rasters_with_ValorDetectionMana
             pr_metrics[0]["value"][value][threshold][metric] == expected_value
         )
 
+    # test that we get a NotImplementedError if we try to calculate DetailedPRCurves with rasters
+    manager = managers.ValorDetectionManager(
+        metrics_to_return=[
+            enums.MetricType.DetailedPrecisionRecallCurve,
+        ],
+    )
+
+    manager.add_data(
+        groundtruths=evaluate_detection_functional_test_groundtruths_with_rasters,
+        predictions=evaluate_detection_functional_test_predictions_with_rasters,
+    )
+
+    with pytest.raises(NotImplementedError):
+        manager.evaluate()
+
 
 def test_evaluate_mixed_annotations_with_ValorDetectionManager(
     evaluate_mixed_annotations_inputs: tuple,

--- a/core/tests/unit-tests/test_geometry.py
+++ b/core/tests/unit-tests/test_geometry.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 from valor_core import geometry
 from valor_core.schemas import (
@@ -1039,6 +1040,242 @@ def test_calculate_iou():
         ):
             iou = geometry.calculate_iou(bbox1=bbox1, bbox2=bbox2)
             assert expected == round(iou, 4)
+
+
+def test_calculate_raster_iou():
+    filled_8x8 = np.full((8, 8), True)
+    filled_10x10 = (np.full((10, 10), True),)
+
+    series1 = pd.Series(
+        [
+            filled_10x10,
+            filled_10x10,
+            [
+                [True, True, True, True, True, False, False, False],
+                [True, True, True, True, True, False, False, False],
+                [True, True, True, True, True, False, False, False],
+                [True, True, True, True, True, False, False, False],
+                [True, True, True, True, True, False, False, False],
+                [True, True, True, True, True, False, False, False],
+                [True, True, True, True, True, False, False, False],
+                [True, True, True, True, True, False, False, False],
+            ],
+            filled_8x8,
+            filled_8x8,
+        ]
+    )
+
+    series2 = pd.Series(
+        [
+            [
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, True, True, True, True],
+            ],
+            [
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+                [
+                    True,
+                    True,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+            ],
+            [
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+            ],
+            [
+                [False, False, False, False, True, True, True, True],
+                [False, False, False, False, True, True, True, True],
+                [False, False, False, False, True, True, True, True],
+                [False, False, False, False, True, True, True, True],
+                [False, False, False, False, False, False, False, False],
+                [False, False, False, False, False, False, False, False],
+                [False, False, False, False, False, False, False, False],
+                [False, False, False, False, False, False, False, False],
+            ],
+            [
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [False, False, False, False, False, True, True, True],
+                [True, True, True, False, False, True, True, True],
+                [True, True, True, False, False, True, True, True],
+                [True, True, True, False, False, True, True, True],
+                [True, True, True, False, False, True, True, True],
+            ],
+        ]
+    )
+
+    result = geometry.calculate_raster_ious(series1, series2)
+    assert (result == [1, 0.5, 0, 0.25, 36 / 64]).all()
+
+    # check that we throw an error if the series aren't the same length
+    series1 = pd.Series(
+        [
+            filled_10x10,
+            filled_10x10,
+        ]
+    )
+
+    series2 = pd.Series(
+        [
+            filled_10x10,
+            filled_10x10,
+            filled_10x10,
+        ]
+    )
+    with pytest.raises(ValueError) as e:
+        geometry.calculate_raster_ious(series1, series2)
+    assert (
+        "Series of rasters must be the same length to calculate IOUs."
+        in str(e)
+    )
+
+    # check that we don't compare rasters that aren't the same size
+    series1 = pd.Series(
+        [
+            filled_10x10,
+            filled_10x10,
+        ]
+    )
+
+    series2 = pd.Series(
+        [
+            filled_10x10,
+            filled_8x8,
+        ]
+    )
+    with pytest.raises(ValueError) as e:
+        geometry.calculate_raster_ious(series1, series2)
+    assert "operands could not be broadcast together with shapes" in str(e)
 
 
 def test_is_axis_aligned(box_points, skewed_box_points, rotated_box_points):

--- a/core/valor_core/detection.py
+++ b/core/valor_core/detection.py
@@ -105,7 +105,7 @@ def _calculate_iou(
         )
         union_ = (
             joint_df.apply(
-                geometry.calculate_raster_union,
+                geometry.calculate_raster_sum_pixels_of_two_images,
                 axis=1,
             )
             - intersection_

--- a/core/valor_core/detection.py
+++ b/core/valor_core/detection.py
@@ -99,16 +99,11 @@ def _calculate_iou(
             joint_df["iou_"] = 0
 
     else:
-        intersection_ = joint_df.apply(
-            geometry.calculate_raster_intersection,
-            axis=1,
-        )
-        union_ = joint_df.apply(
-            geometry.calculate_raster_union,
-            axis=1,
-        )
 
-        joint_df["iou_"] = intersection_ / union_
+        joint_df["iou_"] = geometry.calculate_raster_ious(
+            joint_df["converted_geometry_gt"],
+            joint_df["converted_geometry_pd"],
+        )
 
     return joint_df
 

--- a/core/valor_core/detection.py
+++ b/core/valor_core/detection.py
@@ -103,12 +103,9 @@ def _calculate_iou(
             geometry.calculate_raster_intersection,
             axis=1,
         )
-        union_ = (
-            joint_df.apply(
-                geometry.calculate_raster_sum_pixels_of_two_images,
-                axis=1,
-            )
-            - intersection_
+        union_ = joint_df.apply(
+            geometry.calculate_raster_union,
+            axis=1,
         )
 
         joint_df["iou_"] = intersection_ / union_

--- a/core/valor_core/detection.py
+++ b/core/valor_core/detection.py
@@ -623,8 +623,8 @@ def _calculate_detailed_pr_metrics(
 
     if _check_if_series_contains_masks(
         detailed_pr_joint_df.loc[
-            detailed_pr_joint_df["converted_geometry_pd"].notnull(),
-            "converted_geometry_pd",
+            detailed_pr_joint_df["converted_geometry_gt"].notnull(),
+            "converted_geometry_gt",
         ]
     ) or _check_if_series_contains_masks(
         detailed_pr_joint_df.loc[

--- a/core/valor_core/geometry.py
+++ b/core/valor_core/geometry.py
@@ -1,5 +1,6 @@
 import numba
 import numpy as np
+import pandas as pd
 import shapely.affinity
 from shapely.geometry import Polygon as ShapelyPolygon
 
@@ -244,3 +245,42 @@ def is_rotated(bbox: list[tuple[float, float]]) -> bool:
         True if the bounding box is rotated, otherwise False.
     """
     return not is_axis_aligned(bbox) and not is_skewed(bbox)
+
+
+def calculate_raster_intersection(row: pd.Series) -> pd.Series:
+    """
+    Calculate the raster intersection for a given row in a pandas DataFrame. This function is intended to be used with .apply.
+
+    Parameters
+    ----------
+    row : pd.Series
+        A row of a pandas.DataFrame containing two masks in the columns "converted_geometry_pd" and "converted_geometry_gt".
+
+    Returns
+    ----------
+    pd.Series
+        A Series indicating the intersection of two masks.
+    """
+    return np.logical_and(
+        row["converted_geometry_pd"], row["converted_geometry_gt"]
+    ).sum()
+
+
+def calculate_raster_union(row: pd.Series) -> pd.Series:
+    """
+    Calculate the raster union for a given row in a pandas DataFrame. This function is intended to be used with .apply.
+
+    Parameters
+    ----------
+    row : pd.Series
+        A row of a pandas.DataFrame containing two masks in the columns "converted_geometry_pd" and "converted_geometry_gt".
+
+    Returns
+    ----------
+    pd.Series
+        A Series indicating the union of two masks.
+    """
+
+    return np.sum(row["converted_geometry_gt"]) + np.sum(
+        row["converted_geometry_pd"]
+    )

--- a/core/valor_core/geometry.py
+++ b/core/valor_core/geometry.py
@@ -266,9 +266,9 @@ def calculate_raster_intersection(row: pd.Series) -> pd.Series:
     ).sum()
 
 
-def calculate_raster_sum_pixels_of_two_images(row: pd.Series) -> pd.Series:
+def calculate_raster_union(row: pd.Series) -> pd.Series:
     """
-    Calculate the sum of pixels across two images for a given row in a pandas DataFrame. When we subtract the intersection series from this output, we expect to get back the union for all sets of images. This function is intended to be used with .apply.
+    Calculate the union across two rasters for a given row in a pandas DataFrame. This function is intended to be used with .apply.
 
     Parameters
     ----------
@@ -278,7 +278,7 @@ def calculate_raster_sum_pixels_of_two_images(row: pd.Series) -> pd.Series:
     Returns
     ----------
     pd.Series
-        A Series indicating the sum of pixels across two masks.
+        A Series indicating the union of two masks.
     """
 
     return np.logical_or(

--- a/core/valor_core/geometry.py
+++ b/core/valor_core/geometry.py
@@ -281,6 +281,6 @@ def calculate_raster_sum_pixels_of_two_images(row: pd.Series) -> pd.Series:
         A Series indicating the sum of pixels across two masks.
     """
 
-    return np.sum(row["converted_geometry_gt"]) + np.sum(
-        row["converted_geometry_pd"]
-    )
+    return np.logical_or(
+        row["converted_geometry_pd"], row["converted_geometry_gt"]
+    ).sum()

--- a/core/valor_core/geometry.py
+++ b/core/valor_core/geometry.py
@@ -9,7 +9,7 @@ from shapely.geometry import Polygon as ShapelyPolygon
 np.seterr(divide="ignore", invalid="ignore")
 
 
-@numba.jit(nopython=True)
+@numba.jit(nopython=True, parallel=True)
 def calculate_axis_aligned_bbox_intersection(
     bbox1: np.ndarray, bbox2: np.ndarray
 ) -> float:
@@ -45,7 +45,7 @@ def calculate_axis_aligned_bbox_intersection(
     return intersection_area
 
 
-@numba.jit(nopython=True)
+@numba.jit(nopython=True, parallel=True)
 def calculate_axis_aligned_bbox_union(
     bbox1: np.ndarray, bbox2: np.ndarray
 ) -> float:
@@ -79,7 +79,7 @@ def calculate_axis_aligned_bbox_union(
     return union_area
 
 
-@numba.jit(nopython=True)
+@numba.jit(nopython=True, parallel=True)
 def calculate_axis_aligned_bbox_iou(
     bbox1: np.ndarray, bbox2: np.ndarray
 ) -> float:

--- a/core/valor_core/geometry.py
+++ b/core/valor_core/geometry.py
@@ -9,7 +9,7 @@ from shapely.geometry import Polygon as ShapelyPolygon
 np.seterr(divide="ignore", invalid="ignore")
 
 
-@numba.jit(nopython=True, parallel=True)
+@numba.jit(nopython=True)
 def calculate_axis_aligned_bbox_intersection(
     bbox1: np.ndarray, bbox2: np.ndarray
 ) -> float:
@@ -45,7 +45,7 @@ def calculate_axis_aligned_bbox_intersection(
     return intersection_area
 
 
-@numba.jit(nopython=True, parallel=True)
+@numba.jit(nopython=True)
 def calculate_axis_aligned_bbox_union(
     bbox1: np.ndarray, bbox2: np.ndarray
 ) -> float:
@@ -79,7 +79,7 @@ def calculate_axis_aligned_bbox_union(
     return union_area
 
 
-@numba.jit(nopython=True, parallel=True)
+@numba.jit(nopython=True)
 def calculate_axis_aligned_bbox_iou(
     bbox1: np.ndarray, bbox2: np.ndarray
 ) -> float:
@@ -266,9 +266,9 @@ def calculate_raster_intersection(row: pd.Series) -> pd.Series:
     ).sum()
 
 
-def calculate_raster_union(row: pd.Series) -> pd.Series:
+def calculate_raster_sum_pixels_of_two_images(row: pd.Series) -> pd.Series:
     """
-    Calculate the raster union for a given row in a pandas DataFrame. This function is intended to be used with .apply.
+    Calculate the sum of pixels across two images for a given row in a pandas DataFrame. When we subtract the intersection series from this output, we expect to get back the union for all sets of images. This function is intended to be used with .apply.
 
     Parameters
     ----------
@@ -278,7 +278,7 @@ def calculate_raster_union(row: pd.Series) -> pd.Series:
     Returns
     ----------
     pd.Series
-        A Series indicating the union of two masks.
+        A Series indicating the sum of pixels across two masks.
     """
 
     return np.sum(row["converted_geometry_gt"]) + np.sum(


### PR DESCRIPTION
## Improvements
- Fix a bug in the benchmarking script where we weren't actually telling `valor_core` to calculate `DetailedPrecisionRecallCurve`
- Throw a `NotImplementedError` when a user tries to calculate `DetailedPrecisionRecallCurve` using `AnnotationType.RASTER`.
    - Currently, `valor_core` will try to produce (datum_uid, *mask*) pairs, which easily leads to OOM issues since we're creating sets of tuples, each containing relatively large masks
    -  These curves were never intended to be used with rasters (just bounding boxes and polygons), so I'm recommending we just throw a `NotImplementedError` for now. when we re-prioritize DetailedPRCurves in the future, we can discuss what the right output is for this metric.
- Disable `compute_detailed` for the Box and Polygon OD benchmarks since a) they make the tests take a while to run (~80 seconds for just one run of 5000 `Box` datums; 213 seconds for one Polygon run) and b) profiling and improving these PR curves is low priority right now. We can try adding them back after Justin merges his PRs.
- Update the `valor_core` OD benchmarks to use the ValorDetectionManager class 
- Refactor the raster IOU function to make it easier to read