### PR TITLE
improve toxicity external integration tests

### DIFF
--- a/integration_tests/external/conftest.py
+++ b/integration_tests/external/conftest.py
@@ -758,7 +758,7 @@ def toxicity_datums(
 def toxicity_predictions() -> list[str]:
     return [
         """My opponent's opinion is incorrect because they are not accounting for the difference in agricultural output.""",
-        """I don't think we should increase taxes. My opponent is an idiot. They should just give up if they know what's good for them.""",
+        """My opponent is an idiot. They should just give up if they know what's good for them.""",
         """Fox news is a right wing news outlet. Fox News claimed that the left wing president is an idiot in their latest article.""",
     ]
 

--- a/integration_tests/external/test_text_generation_no_mock.py
+++ b/integration_tests/external/test_text_generation_no_mock.py
@@ -387,7 +387,7 @@ def test_toxicity_with_openai(
             "Toxicity": 0.0,
         },
         "uid1": {
-            "Toxicity": 0.6666666666666666,
+            "Toxicity": 1.0,
         },
         "uid2": {
             "Toxicity": 0.0,
@@ -721,7 +721,7 @@ def test_toxicity_with_mistral(
             "Toxicity": 0.0,
         },
         "uid1": {
-            "Toxicity": 0.6666666666666666,
+            "Toxicity": 1.0,
         },
         "uid2": {
             "Toxicity": 0.0,


### PR DESCRIPTION
Improve the external integration tests for toxicity by simplifying them to increase the consistency at which they pass.