### PR TITLE
Vectorize IOU calcs for axis-aligned bboxes

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "importlib_metadata; python_version < '3.8'",
     "pandas>=2.2.2",
     "pandas-stubs",
-    "pandas[performance]",
     "tqdm",
     "requests",
     "shapely"


### PR DESCRIPTION
## Improvements
- Refactor IOU calculations to use vector operations, bringing axis-aligned bbox benchmark time below 10 seconds
- Remove pandas[performance] since we're no longer using numba's JIT decorator. benchmark times didn't change after removal