### PR TITLE
Fix bug in `valor_core` where some true positives weren't being correctly deassigned

### DIFF
--- a/core/tests/conftest_outputs.py
+++ b/core/tests/conftest_outputs.py
@@ -2895,3 +2895,42 @@ def detailed_curve_examples_output():
     }
 
     return expected_outputs
+
+
+@pytest.fixture
+def check_correct_deassignment_of_true_positive_boolean_outputs() -> list:
+    return [
+        {
+            "label": {"key": "class", "value": "1"},
+            "parameters": {"iou": 0.5},
+            "value": 0.504950495049505,
+            "type": "AP",
+        },
+        {
+            "parameters": {"label_key": "class", "iou": 0.5},
+            "value": 0.504950495049505,
+            "type": "mAP",
+        },
+        {
+            "label": {"key": "class", "value": "1"},
+            "parameters": {"ious": [0.5]},
+            "value": 0.504950495049505,
+            "type": "APAveragedOverIOUs",
+        },
+        {
+            "parameters": {"label_key": "class", "ious": [0.5]},
+            "value": 0.504950495049505,
+            "type": "mAPAveragedOverIOUs",
+        },
+        {
+            "label": {"key": "class", "value": "1"},
+            "parameters": {"ious": [0.5]},
+            "value": 0.5,
+            "type": "AR",
+        },
+        {
+            "parameters": {"label_key": "class", "ious": [0.5]},
+            "value": 0.5,
+            "type": "mAR",
+        },
+    ]

--- a/core/tests/functional-tests/test_detection.py
+++ b/core/tests/functional-tests/test_detection.py
@@ -1632,3 +1632,30 @@ def test_evaluate_detection_pr_fp(evaluate_detection_pr_fp_inputs):
         ]["count"]
         == 0
     )
+
+
+def test_correct_deassignment_of_true_positive_boolean(
+    check_correct_deassignment_of_true_positive_boolean_inputs: tuple,
+    check_correct_deassignment_of_true_positive_boolean_outputs: list,
+):
+    """
+    Test a bug where multiple predictions for a single groundtruth / label could both be considered true positives as long as there was at least one other prediction in between them.
+    For this test, only the first prediction in calculation_df should be considered a true positive; all the others should be marked as false positives.
+    """
+
+    (
+        groundtruths,
+        predictions,
+    ) = check_correct_deassignment_of_true_positive_boolean_inputs
+    metrics = evaluate_detection(
+        groundtruths=groundtruths,
+        predictions=predictions,
+        iou_thresholds_to_compute=[0.5],
+        iou_thresholds_to_return=[0.5],
+    ).metrics
+
+    expected = check_correct_deassignment_of_true_positive_boolean_outputs
+    for m in metrics:
+        assert m in expected
+    for m in expected:
+        assert m in metrics

--- a/core/tests/functional-tests/test_detection_manager.py
+++ b/core/tests/functional-tests/test_detection_manager.py
@@ -1723,3 +1723,33 @@ def test_evaluate_detection_with_label_maps_and_ValorDetectionManager(
             key="class_name", value="cat", score=None
         ): schemas.Label(key="foo", value="bar", score=None),
     }
+
+
+def test_correct_deassignment_of_true_positive_boolean_with_ValorDetectionManager(
+    check_correct_deassignment_of_true_positive_boolean_inputs: tuple,
+    check_correct_deassignment_of_true_positive_boolean_outputs: list,
+):
+    """
+    Test a bug where multiple predictions for a single groundtruth / label could both be considered true positives as long as there was at least one other prediction in between them.
+    For this test, only the first prediction in calculation_df should be considered a true positive; all the others should be marked as false positives.
+    """
+
+    (
+        groundtruths,
+        predictions,
+    ) = check_correct_deassignment_of_true_positive_boolean_inputs
+
+    manager = managers.ValorDetectionManager(
+        iou_thresholds_to_compute=[0.5],
+        iou_thresholds_to_return=[0.5],
+    )
+
+    manager.add_data(groundtruths=groundtruths, predictions=predictions)
+
+    metrics = manager.evaluate().metrics
+
+    expected = check_correct_deassignment_of_true_positive_boolean_outputs
+    for m in metrics:
+        assert m in expected
+    for m in expected:
+        assert m in metrics

--- a/core/valor_core/detection.py
+++ b/core/valor_core/detection.py
@@ -126,13 +126,16 @@ def _calculate_label_id_level_metrics(
     calculation_df["recall_true_positive_flag"] = (
         calculation_df["iou_"] >= calculation_df["iou_threshold"]
     ) & (calculation_df["score"] >= recall_score_threshold)
-    # only consider the highest scoring true positive as an actual true positive
+
+    # only consider the highest scoring true positive as an actual true positive'
     calculation_df["recall_true_positive_flag"] = calculation_df[
         "recall_true_positive_flag"
     ] & (
-        ~calculation_df.groupby(
-            ["label_id", "label", "iou_threshold", "id_gt"], as_index=False
-        )["recall_true_positive_flag"].shift(1, fill_value=False)
+        calculation_df[calculation_df["recall_true_positive_flag"]]
+        .groupby(["label_id", "label", "iou_threshold", "id_gt"])[
+            "recall_true_positive_flag"
+        ]
+        .transform(lambda x: [True] + [False] * (len(x) - 1))
     )
 
     calculation_df["precision_true_positive_flag"] = (
@@ -141,9 +144,11 @@ def _calculate_label_id_level_metrics(
     calculation_df["precision_true_positive_flag"] = calculation_df[
         "precision_true_positive_flag"
     ] & (
-        ~calculation_df.groupby(
-            ["label_id", "iou_threshold", "id_gt"], as_index=False
-        )["precision_true_positive_flag"].shift(1, fill_value=False)
+        calculation_df[calculation_df["precision_true_positive_flag"]]
+        .groupby(["label_id", "label", "iou_threshold", "id_gt"])[
+            "precision_true_positive_flag"
+        ]
+        .transform(lambda x: [True] + [False] * (len(x) - 1))
     )
 
     calculation_df["recall_false_positive_flag"] = ~calculation_df[

--- a/core/valor_core/detection.py
+++ b/core/valor_core/detection.py
@@ -135,7 +135,8 @@ def _calculate_label_id_level_metrics(
         .groupby(["label_id", "label", "iou_threshold", "id_gt"])[
             "recall_true_positive_flag"
         ]
-        .transform(lambda x: [True] + [False] * (len(x) - 1))
+        .cumsum()
+        .eq(1)
     )
 
     calculation_df["precision_true_positive_flag"] = (
@@ -148,7 +149,8 @@ def _calculate_label_id_level_metrics(
         .groupby(["label_id", "label", "iou_threshold", "id_gt"])[
             "precision_true_positive_flag"
         ]
-        .transform(lambda x: [True] + [False] * (len(x) - 1))
+        .cumsum()
+        .eq(1)
     )
 
     calculation_df["recall_false_positive_flag"] = ~calculation_df[


### PR DESCRIPTION
## Improvements
- Addresses #735 by fixing a bug where the use of `.shift()` to identify irrelevant true positives (TPs) wouldn't correctly catch all false positives if there was a non-TP wedged in between two TPs
- Added tests to confirm expected behavior
- Confirmed that this change didn't impact benchmark runtimes