### PR TITLE
Fix DetailedPRCurve examples for classification tasks

### DIFF
--- a/core/tests/conftest_inputs.py
+++ b/core/tests/conftest_inputs.py
@@ -3239,6 +3239,52 @@ def multiclass_pr_curve_predictions():
 
 
 @pytest.fixture
+def multiclass_pr_curve_check_zero_count_examples_groundtruths():
+    return [
+        schemas.GroundTruth(
+            datum=schemas.Datum(
+                uid="uid0",
+                metadata={
+                    "height": 900,
+                    "width": 300,
+                },
+            ),
+            annotations=[
+                schemas.Annotation(
+                    labels=[
+                        schemas.Label(key="k", value="ant"),
+                    ],
+                ),
+            ],
+        ),
+    ]
+
+
+@pytest.fixture
+def multiclass_pr_curve_check_zero_count_examples_predictions():
+    return [
+        schemas.Prediction(
+            datum=schemas.Datum(
+                uid="uid0",
+                metadata={
+                    "height": 900,
+                    "width": 300,
+                },
+            ),
+            annotations=[
+                schemas.Annotation(
+                    labels=[
+                        schemas.Label(key="k", value="ant", score=0.15),
+                        schemas.Label(key="k", value="bee", score=0.48),
+                        schemas.Label(key="k", value="cat", score=0.37),
+                    ],
+                )
+            ],
+        ),
+    ]
+
+
+@pytest.fixture
 def evaluate_detection_false_negatives_single_image_baseline_inputs():
     groundtruths = [
         schemas.GroundTruth(

--- a/core/tests/conftest_inputs.py
+++ b/core/tests/conftest_inputs.py
@@ -3285,6 +3285,90 @@ def multiclass_pr_curve_check_zero_count_examples_predictions():
 
 
 @pytest.fixture
+def multiclass_pr_curve_check_true_negatives_groundtruths():
+    return [
+        schemas.GroundTruth(
+            datum=schemas.Datum(
+                uid="uid0",
+                metadata={
+                    "height": 900,
+                    "width": 300,
+                },
+            ),
+            annotations=[
+                schemas.Annotation(
+                    labels=[
+                        schemas.Label(key="dataset1", value="ant"),
+                    ],
+                ),
+            ],
+        ),
+        schemas.GroundTruth(
+            datum=schemas.Datum(
+                uid="uid1",
+                metadata={
+                    "height": 900,
+                    "width": 300,
+                },
+            ),
+            annotations=[
+                schemas.Annotation(
+                    labels=[
+                        schemas.Label(key="dataset2", value="egg"),
+                    ],
+                ),
+            ],
+        ),
+    ]
+
+
+@pytest.fixture
+def multiclass_pr_curve_check_true_negatives_predictions():
+    return [
+        schemas.Prediction(
+            datum=schemas.Datum(
+                uid="uid0",
+                metadata={
+                    "height": 900,
+                    "width": 300,
+                },
+            ),
+            annotations=[
+                schemas.Annotation(
+                    labels=[
+                        schemas.Label(key="dataset1", value="ant", score=0.15),
+                        schemas.Label(key="dataset1", value="bee", score=0.48),
+                        schemas.Label(key="dataset1", value="cat", score=0.37),
+                    ],
+                )
+            ],
+        ),
+        schemas.Prediction(
+            datum=schemas.Datum(
+                uid="uid1",
+                metadata={
+                    "height": 900,
+                    "width": 300,
+                },
+            ),
+            annotations=[
+                schemas.Annotation(
+                    labels=[
+                        schemas.Label(key="dataset2", value="egg", score=0.15),
+                        schemas.Label(
+                            key="dataset2", value="milk", score=0.48
+                        ),
+                        schemas.Label(
+                            key="dataset2", value="flour", score=0.37
+                        ),
+                    ],
+                )
+            ],
+        ),
+    ]
+
+
+@pytest.fixture
 def evaluate_detection_false_negatives_single_image_baseline_inputs():
     groundtruths = [
         schemas.GroundTruth(

--- a/core/tests/conftest_outputs.py
+++ b/core/tests/conftest_outputs.py
@@ -2892,6 +2892,21 @@ def detailed_curve_examples_output():
             ("datum2",),
             ("datum0",),
         },
+        # check cases where we shouldn't have any examples since the count is zero
+        ("bee", 0.3, "fn", "misclassifications"): set(),
+        ("dog", 0.1, "tn", "all"): set(),
+    }
+
+    return expected_outputs
+
+
+@pytest.fixture
+def detailed_curve_examples_check_zero_count_examples_output():
+    expected_outputs = {
+        ("ant", 0.05, "fp", "misclassifications"): 0,
+        ("ant", 0.95, "tn", "all"): 0,
+        ("bee", 0.2, "fn", "misclassifications"): 0,
+        ("cat", 0.2, "fn", "misclassifications"): 0,
     }
 
     return expected_outputs

--- a/core/tests/conftest_outputs.py
+++ b/core/tests/conftest_outputs.py
@@ -2910,3 +2910,21 @@ def detailed_curve_examples_check_zero_count_examples_output():
     }
 
     return expected_outputs
+
+
+@pytest.fixture
+def detailed_curve_examples_check_true_negatives_output():
+    expected_outputs = {
+        ("bee", 0.05, "tn", "all"): {
+            ("uid1",),
+        },
+        ("bee", 0.15, "tn", "all"): {
+            ("uid1",),
+        },
+        ("bee", 0.95, "tn", "all"): {
+            ("uid1",),
+            ("uid0",),
+        },
+    }
+
+    return expected_outputs

--- a/core/tests/functional-tests/test_classification.py
+++ b/core/tests/functional-tests/test_classification.py
@@ -601,8 +601,11 @@ def test_pr_curves_multiple_predictions_per_groundtruth(
 
 def test_detailed_curve_examples(
     multiclass_pr_curve_groundtruths: list,
+    multiclass_pr_curve_check_zero_count_examples_groundtruths: list,
     multiclass_pr_curve_predictions: list,
+    multiclass_pr_curve_check_zero_count_examples_predictions: list,
     detailed_curve_examples_output: dict,
+    detailed_curve_examples_check_zero_count_examples_output: dict,
 ):
     """Test that we get back the right examples in DetailedPRCurves."""
 
@@ -624,3 +627,27 @@ def test_detailed_curve_examples(
             )
             == expected
         )
+
+    # test additional cases to make sure that we aren't returning examples where count == 0
+    eval_job = evaluate_classification(
+        groundtruths=multiclass_pr_curve_check_zero_count_examples_groundtruths,
+        predictions=multiclass_pr_curve_check_zero_count_examples_predictions,
+        metrics_to_return=[enums.MetricType.DetailedPrecisionRecallCurve],
+    )
+    output = eval_job.metrics[0]["value"]
+
+    for (
+        key,
+        expected,
+    ) in detailed_curve_examples_check_zero_count_examples_output.items():
+        assert (
+            len(
+                output[key[0]][key[1]][key[2]]["observations"][key[3]][
+                    "examples"
+                ]
+            )
+            == expected
+        )
+        assert (
+            output[key[0]][key[1]][key[2]]["observations"][key[3]]["count"]
+        ) == 0

--- a/core/tests/functional-tests/test_classification.py
+++ b/core/tests/functional-tests/test_classification.py
@@ -668,9 +668,6 @@ def test_detailed_curve_examples(
         key,
         expected,
     ) in detailed_curve_examples_check_true_negatives_output.items():
-        import pdb
-
-        pdb.set_trace()
         assert (
             set(
                 output[key[0]][key[1]][key[2]]["observations"][key[3]][

--- a/core/tests/functional-tests/test_classification.py
+++ b/core/tests/functional-tests/test_classification.py
@@ -602,10 +602,13 @@ def test_pr_curves_multiple_predictions_per_groundtruth(
 def test_detailed_curve_examples(
     multiclass_pr_curve_groundtruths: list,
     multiclass_pr_curve_check_zero_count_examples_groundtruths: list,
+    multiclass_pr_curve_check_true_negatives_groundtruths: list,
     multiclass_pr_curve_predictions: list,
     multiclass_pr_curve_check_zero_count_examples_predictions: list,
+    multiclass_pr_curve_check_true_negatives_predictions: list,
     detailed_curve_examples_output: dict,
     detailed_curve_examples_check_zero_count_examples_output: dict,
+    detailed_curve_examples_check_true_negatives_output: dict,
 ):
     """Test that we get back the right examples in DetailedPRCurves."""
 
@@ -651,3 +654,28 @@ def test_detailed_curve_examples(
         assert (
             output[key[0]][key[1]][key[2]]["observations"][key[3]]["count"]
         ) == 0
+
+    # test additional cases to make sure that we're getting back enough true negative examples
+    eval_job = evaluate_classification(
+        groundtruths=multiclass_pr_curve_check_true_negatives_groundtruths,
+        predictions=multiclass_pr_curve_check_true_negatives_predictions,
+        metrics_to_return=[enums.MetricType.DetailedPrecisionRecallCurve],
+        pr_curve_max_examples=5,
+    )
+    output = eval_job.metrics[0]["value"]
+
+    for (
+        key,
+        expected,
+    ) in detailed_curve_examples_check_true_negatives_output.items():
+        import pdb
+
+        pdb.set_trace()
+        assert (
+            set(
+                output[key[0]][key[1]][key[2]]["observations"][key[3]][
+                    "examples"
+                ]
+            )
+            == expected
+        )

--- a/core/valor_core/classification.py
+++ b/core/valor_core/classification.py
@@ -1005,7 +1005,11 @@ def _calculate_pr_curves(
                     "observations": {
                         "all": {
                             "count": row["true_positives"],
-                            "examples": row["true_positive_flag_samples"],
+                            "examples": (
+                                row["true_positive_flag_samples"]
+                                if row["true_positives"]
+                                else []
+                            ),
                         }
                     },
                 },
@@ -1014,7 +1018,11 @@ def _calculate_pr_curves(
                     "observations": {
                         "all": {
                             "count": row["true_negatives"],
-                            "examples": row["true_negative_flag_samples"],
+                            "examples": (
+                                row["true_negative_flag_samples"]
+                                if row["true_negatives"]
+                                else []
+                            ),
                         }
                     },
                 },
@@ -1023,15 +1031,23 @@ def _calculate_pr_curves(
                     "observations": {
                         "misclassifications": {
                             "count": row["misclassification_false_negatives"],
-                            "examples": row[
-                                "misclassification_false_negative_flag_samples"
-                            ],
+                            "examples": (
+                                row[
+                                    "misclassification_false_negative_flag_samples"
+                                ]
+                                if row["misclassification_false_negatives"]
+                                else []
+                            ),
                         },
                         "no_predictions": {
                             "count": row["no_predictions_false_negatives"],
-                            "examples": row[
-                                "no_predictions_false_negative_flag_samples"
-                            ],
+                            "examples": (
+                                row[
+                                    "no_predictions_false_negative_flag_samples"
+                                ]
+                                if row["no_predictions_false_negatives"]
+                                else []
+                            ),
                         },
                     },
                 },
@@ -1040,9 +1056,13 @@ def _calculate_pr_curves(
                     "observations": {
                         "misclassifications": {
                             "count": row["misclassification_false_positives"],
-                            "examples": row[
-                                "misclassification_false_positive_flag_samples"
-                            ],
+                            "examples": (
+                                row[
+                                    "misclassification_false_positive_flag_samples"
+                                ]
+                                if row["misclassification_false_positives"]
+                                else []
+                            ),
                         },
                     },
                 },


### PR DESCRIPTION
## Improvements
- Ensure that we're correctly accounting for all types of true negatives when pulling examples for `DetailedPrecisionRecallCurve`, fixing #739 
- Add a check to make sure we don't pass any examples when the count of a PR category is zero, fixing #737
- Add tests to check for these issues
- Confirm that benchmarks are unaffected by change