### PR TITLE
Make OpenAI and Mistral optional dependencies of valor core

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -14,8 +14,6 @@ dependencies = [
     "tqdm",
     "requests",
     "shapely",
-    "openai",
-    "mistralai >= 1.0",
     "nltk",
     "rouge_score",
     "evaluate"
@@ -29,6 +27,8 @@ requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
+mistral = ["mistralai >= 1.0"]
+openai = ["openai"]
 test = ["pytest", "coverage"]
 
 [tool.black]

--- a/core/tests/functional-tests/test_llm_clients.py
+++ b/core/tests/functional-tests/test_llm_clients.py
@@ -3,18 +3,30 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-from mistralai.models import (
-    AssistantMessage,
-    ChatCompletionChoice,
-    ChatCompletionResponse,
-    UsageInfo,
-)
-from mistralai.models.sdkerror import SDKError as MistralSDKError
-from openai import OpenAIError
-from openai.types.chat import ChatCompletionMessage
-from openai.types.chat.chat_completion import ChatCompletion, Choice
-from openai.types.completion_usage import CompletionUsage
-from pydantic import ValidationError
+
+try:
+    from mistralai.models import (
+        AssistantMessage,
+        ChatCompletionChoice,
+        ChatCompletionResponse,
+        UsageInfo,
+    )
+    from mistralai.models.sdkerror import SDKError as MistralSDKError
+
+    MISTRALAI_INSTALLED = True
+except ImportError:
+    MISTRALAI_INSTALLED = False
+
+try:
+    from openai import OpenAIError
+    from openai.types.chat import ChatCompletionMessage
+    from openai.types.chat.chat_completion import ChatCompletion, Choice
+    from openai.types.completion_usage import CompletionUsage
+
+    OPENAI_INSTALLED = True
+except ImportError:
+    OPENAI_INSTALLED = False
+
 from valor_core.exceptions import InvalidLLMResponseError
 from valor_core.llm_clients import (
     LLMClient,
@@ -1319,28 +1331,32 @@ def test_LLMClient(monkeypatch):
         client.toxicity("some text")
 
 
+@pytest.mark.skipif(
+    not OPENAI_INSTALLED,
+    reason="Openai is not installed.",
+)
 def test_WrappedOpenAIClient():
-    def _create_bad_request(model, messages, seed) -> ChatCompletion:
+    def _create_bad_request(model, messages, seed):
         raise ValueError
 
     def _create_mock_chat_completion_with_bad_length(
         model, messages, seed
-    ) -> ChatCompletion:
-        return ChatCompletion(
+    ) -> ChatCompletion:  # type: ignore - test is not run if openai is not installed
+        return ChatCompletion(  # type: ignore - test is not run if openai is not installed
             id="foo",
             model="gpt-3.5-turbo",
             object="chat.completion",
             choices=[
-                Choice(
+                Choice(  # type: ignore - test is not run if openai is not installed
                     finish_reason="length",
                     index=0,
-                    message=ChatCompletionMessage(
+                    message=ChatCompletionMessage(  # type: ignore - test is not run if openai is not installed
                         content="some response",
                         role="assistant",
                     ),
                 )
             ],
-            usage=CompletionUsage(
+            usage=CompletionUsage(  # type: ignore - test is not run if openai is not installed
                 completion_tokens=1, prompt_tokens=2, total_tokens=3
             ),
             created=int(datetime.datetime.now().timestamp()),
@@ -1348,43 +1364,43 @@ def test_WrappedOpenAIClient():
 
     def _create_mock_chat_completion_with_content_filter(
         model, messages, seed
-    ) -> ChatCompletion:
-        return ChatCompletion(
+    ) -> ChatCompletion:  # type: ignore - test is not run if openai is not installed
+        return ChatCompletion(  # type: ignore - test is not run if openai is not installed
             id="foo",
             model="gpt-3.5-turbo",
             object="chat.completion",
             choices=[
-                Choice(
+                Choice(  # type: ignore - test is not run if openai is not installed
                     finish_reason="content_filter",
                     index=0,
-                    message=ChatCompletionMessage(
+                    message=ChatCompletionMessage(  # type: ignore - test is not run if openai is not installed
                         content="some response",
                         role="assistant",
                     ),
                 )
             ],
-            usage=CompletionUsage(
+            usage=CompletionUsage(  # type: ignore - test is not run if openai is not installed
                 completion_tokens=1, prompt_tokens=2, total_tokens=3
             ),
             created=int(datetime.datetime.now().timestamp()),
         )
 
-    def _create_mock_chat_completion(model, messages, seed) -> ChatCompletion:
-        return ChatCompletion(
+    def _create_mock_chat_completion(model, messages, seed) -> ChatCompletion:  # type: ignore - test is not run if openai is not installed
+        return ChatCompletion(  # type: ignore - test is not run if openai is not installed
             id="foo",
             model="gpt-3.5-turbo",
             object="chat.completion",
             choices=[
-                Choice(
+                Choice(  # type: ignore - test is not run if openai is not installed
                     finish_reason="stop",
                     index=0,
-                    message=ChatCompletionMessage(
+                    message=ChatCompletionMessage(  # type: ignore - test is not run if openai is not installed
                         content="some response",
                         role="assistant",
                     ),
                 )
             ],
-            usage=CompletionUsage(
+            usage=CompletionUsage(  # type: ignore - test is not run if openai is not installed
                 completion_tokens=1, prompt_tokens=2, total_tokens=3
             ),
             created=int(datetime.datetime.now().timestamp()),
@@ -1392,22 +1408,22 @@ def test_WrappedOpenAIClient():
 
     def _create_mock_chat_completion_none_content(
         model, messages, seed
-    ) -> ChatCompletion:
-        return ChatCompletion(
+    ) -> ChatCompletion:  # type: ignore - test is not run if openai is not installed
+        return ChatCompletion(  # type: ignore - test is not run if openai is not installed
             id="foo",
             model="gpt-3.5-turbo",
             object="chat.completion",
             choices=[
-                Choice(
+                Choice(  # type: ignore - test is not run if openai is not installed
                     finish_reason="stop",
                     index=0,
-                    message=ChatCompletionMessage(
+                    message=ChatCompletionMessage(  # type: ignore - test is not run if openai is not installed
                         content=None,
                         role="assistant",
                     ),
                 )
             ],
-            usage=CompletionUsage(
+            usage=CompletionUsage(  # type: ignore - test is not run if openai is not installed
                 completion_tokens=1, prompt_tokens=2, total_tokens=3
             ),
             created=int(datetime.datetime.now().timestamp()),
@@ -1420,7 +1436,7 @@ def test_WrappedOpenAIClient():
     fake_message = [
         {"role": "system", "content": "You are a helpful assistant."}
     ]
-    with pytest.raises(OpenAIError):
+    with pytest.raises(OpenAIError):  # type: ignore - test is not run if openai is not installed
         client.connect()
         client(fake_message)
 
@@ -1466,23 +1482,27 @@ def test_WrappedOpenAIClient():
     assert client(fake_message) == ""
 
 
+@pytest.mark.skipif(
+    not MISTRALAI_INSTALLED,
+    reason="MistralAI is not installed.",
+)
 def test_WrappedMistralAIClient():
-    def _create_bad_request(model, messages) -> ChatCompletion:
+    def _create_bad_request(model, messages):
         raise ValueError
 
     def _create_mock_chat_completion_with_bad_length(
         model,
         messages,
-    ) -> ChatCompletionResponse:
-        return ChatCompletionResponse(
+    ) -> ChatCompletionResponse:  # type: ignore - test is not run if mistralai is not installed
+        return ChatCompletionResponse(  # type: ignore - test is not run if mistralai is not installed
             id="foo",
             model="gpt-3.5-turbo",
             object="chat.completion",
             choices=[
-                ChatCompletionChoice(
+                ChatCompletionChoice(  # type: ignore - test is not run if mistralai is not installed
                     finish_reason="length",
                     index=0,
-                    message=AssistantMessage(
+                    message=AssistantMessage(  # type: ignore - test is not run if mistralai is not installed
                         role="assistant",
                         content="some response",
                         name=None,  # type: ignore - mistralai issue
@@ -1492,23 +1512,23 @@ def test_WrappedMistralAIClient():
                 )
             ],
             created=int(datetime.datetime.now().timestamp()),
-            usage=UsageInfo(
+            usage=UsageInfo(  # type: ignore - test is not run if mistralai is not installed
                 prompt_tokens=2, total_tokens=4, completion_tokens=199
             ),
         )
 
     def _create_mock_chat_completion(
         model, messages
-    ) -> ChatCompletionResponse:
-        return ChatCompletionResponse(
+    ) -> ChatCompletionResponse:  # type: ignore - test is not run if mistralai is not installed
+        return ChatCompletionResponse(  # type: ignore - test is not run if mistralai is not installed
             id="foo",
             model="gpt-3.5-turbo",
             object="chat.completion",
             choices=[
-                ChatCompletionChoice(
+                ChatCompletionChoice(  # type: ignore - test is not run if mistralai is not installed
                     finish_reason="stop",
                     index=0,
-                    message=AssistantMessage(
+                    message=AssistantMessage(  # type: ignore - test is not run if mistralai is not installed
                         role="assistant",
                         content="some response",
                         name=None,  # type: ignore - mistralai issue
@@ -1518,7 +1538,7 @@ def test_WrappedMistralAIClient():
                 )
             ],
             created=int(datetime.datetime.now().timestamp()),
-            usage=UsageInfo(
+            usage=UsageInfo(  # type: ignore - test is not run if mistralai is not installed
                 prompt_tokens=2, total_tokens=4, completion_tokens=199
             ),
         )
@@ -1528,7 +1548,7 @@ def test_WrappedMistralAIClient():
         api_key="invalid_key", model_name="model_name"
     )
     fake_message = [{"role": "assistant", "content": "content"}]
-    with pytest.raises(MistralSDKError):
+    with pytest.raises(MistralSDKError):  # type: ignore - test is not run if mistralai is not installed
         client.connect()
         client(fake_message)
 
@@ -1588,7 +1608,7 @@ def test_process_message():
     WrappedMistralAIClient()._process_messages(messages=messages)
     MockLLMClient()._process_messages(messages=messages)
 
-    # The clients should raise a ValidationError because "content" is missing in the second message.
+    # The clients should raise a ValueError because "content" is missing in the second message.
     messages = [
         {
             "role": "system",
@@ -1603,9 +1623,9 @@ def test_process_message():
             "content": "The weather is sunny.",
         },
     ]
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValueError):
         WrappedOpenAIClient()._process_messages(messages=messages)
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValueError):
         WrappedMistralAIClient()._process_messages(messages=messages)
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValueError):
         MockLLMClient()._process_messages(messages=messages)

--- a/core/valor_core/llm_clients.py
+++ b/core/valor_core/llm_clients.py
@@ -31,39 +31,6 @@ from valor_core.utilities import trim_and_load_json
 DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant."
 
 
-# @dataclass
-# class Message:
-#     role: str
-#     content: str
-
-#     def __post_init__(self):
-#         """Validate instantiated class."""
-#         if not isinstance(self.role, str):
-#             raise ValueError(
-#                 f"role must be a string, got {type(self.role)} instead."
-#             )
-#         if not isinstance(self.content, str):
-#             raise ValueError(
-#                 f"content must be a string, got {type(self.content)} instead."
-#             )
-
-
-# @dataclass
-# class Messages:
-#     messages: list[Message]
-
-#     def __post_init__(self):
-#         """Validate instantiated class."""
-#         if not isinstance(self.messages, list):
-#             raise ValueError(
-#                 f"messages must be a list, got {type(self.messages)} instead."
-#             )
-#         if not all(isinstance(message, Message) for message in self.messages):
-#             raise ValueError(
-#                 "messages must be a list of Message objects."
-#            )
-
-
 def validate_messages(messages: list[dict[str, str]]):
     """
     Validate that the input is a list of dictionaries with "role" and "content" keys.

--- a/core/valor_core/llm_clients.py
+++ b/core/valor_core/llm_clients.py
@@ -52,6 +52,10 @@ def validate_messages(messages: list[dict[str, str]]):
         raise ValueError(
             'messages must be a list of dictionaries with "role" and "content" keys.'
         )
+    if not all(isinstance(message["role"], str) for message in messages):
+        raise ValueError("All roles in messages must be strings.")
+    if not all(isinstance(message["content"], str) for message in messages):
+        raise ValueError("All content in messages must be strings.")
 
 
 class LLMClient:

--- a/core/valor_core/llm_clients.py
+++ b/core/valor_core/llm_clients.py
@@ -1,8 +1,15 @@
 from typing import Any
 
-from mistralai.sdk import Mistral
-from openai import OpenAI
-from pydantic import BaseModel
+try:
+    from mistralai.sdk import Mistral
+except ImportError:
+    Mistral = None
+
+try:
+    from openai import OpenAI
+except ImportError:
+    OpenAI = None
+
 from valor_core.exceptions import InvalidLLMResponseError
 from valor_core.llm_instructions_analysis import (
     generate_answer_correctness_verdicts_instruction,
@@ -24,13 +31,60 @@ from valor_core.utilities import trim_and_load_json
 DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant."
 
 
-class Message(BaseModel):
-    role: str
-    content: str
+# @dataclass
+# class Message:
+#     role: str
+#     content: str
+
+#     def __post_init__(self):
+#         """Validate instantiated class."""
+#         if not isinstance(self.role, str):
+#             raise ValueError(
+#                 f"role must be a string, got {type(self.role)} instead."
+#             )
+#         if not isinstance(self.content, str):
+#             raise ValueError(
+#                 f"content must be a string, got {type(self.content)} instead."
+#             )
 
 
-class Messages(BaseModel):
-    messages: list[Message]
+# @dataclass
+# class Messages:
+#     messages: list[Message]
+
+#     def __post_init__(self):
+#         """Validate instantiated class."""
+#         if not isinstance(self.messages, list):
+#             raise ValueError(
+#                 f"messages must be a list, got {type(self.messages)} instead."
+#             )
+#         if not all(isinstance(message, Message) for message in self.messages):
+#             raise ValueError(
+#                 "messages must be a list of Message objects."
+#            )
+
+
+def validate_messages(messages: list[dict[str, str]]):
+    """
+    Validate that the input is a list of dictionaries with "role" and "content" keys.
+
+    Parameters
+    ----------
+    messages: list[dict[str, str]]
+        The messages formatted according to the OpenAI standard. Each message in messages is a dictionary with "role" and "content" keys.
+    """
+    if not isinstance(messages, list):
+        raise ValueError(
+            f"messages must be a list, got {type(messages)} instead."
+        )
+    if not all(isinstance(message, dict) for message in messages):
+        raise ValueError("messages must be a list of dictionaries.")
+    if not all(
+        "role" in message and "content" in message for message in messages
+    ):
+        raise ValueError(
+            'messages must be a list of dictionaries with "role" and "content" keys.'
+        )
 
 
 class LLMClient:
@@ -86,7 +140,7 @@ class LLMClient:
             The messages formatted for the API.
         """
         # Validate that the input is a list of dictionaries with "role" and "content" keys.
-        _ = Messages(messages=messages)  # type: ignore
+        validate_messages(messages=messages)  # type: ignore
 
         raise NotImplementedError
 
@@ -1189,6 +1243,11 @@ class WrappedOpenAIClient(LLMClient):
         """
         Setup the connection to the API.
         """
+        if OpenAI is None:
+            raise ImportError(
+                "OpenAI must be installed to use the WrappedOpenAIClient."
+            )
+
         if self.api_key is None:
             self.client = OpenAI()
         else:
@@ -1212,7 +1271,7 @@ class WrappedOpenAIClient(LLMClient):
             The messages are left in the OpenAI standard.
         """
         # Validate that the input is a list of dictionaries with "role" and "content" keys.
-        _ = Messages(messages=messages)  # type: ignore
+        validate_messages(messages=messages)  # type: ignore
 
         return messages
 
@@ -1297,6 +1356,10 @@ class WrappedMistralAIClient(LLMClient):
         """
         Setup the connection to the API.
         """
+        if Mistral is None:
+            raise ImportError(
+                "Mistral must be installed to use the WrappedMistralAIClient."
+            )
         if self.api_key is None:
             self.client = Mistral()
         else:
@@ -1320,7 +1383,7 @@ class WrappedMistralAIClient(LLMClient):
             The messages formatted for Mistral's API. With mistralai>=1.0.0, the messages can be left in the OpenAI standard.
         """
         # Validate that the input is a list of dictionaries with "role" and "content" keys.
-        _ = Messages(messages=messages)  # type: ignore
+        validate_messages(messages=messages)  # type: ignore
 
         return messages
 
@@ -1415,7 +1478,7 @@ class MockLLMClient(LLMClient):
             The messages are left in the OpenAI format.
         """
         # Validate that the input is a list of dictionaries with "role" and "content" keys.
-        _ = Messages(messages=messages)  # type: ignore
+        validate_messages(messages=messages)  # type: ignore
 
         return messages
 


### PR DESCRIPTION
When the text generation metrics were added to valor-core, openai and mistralai were added as dependencies. However, mistralai>=1.0 requires pydantic at least >=2.8.2, which conflicts with packages that use pydantic v1. By making both openai and mistralai optional, users of valor-core get more flexibility to deal with potential conflicts. 

Changes
- openai and mistralai were made optional dependencies in pyproject.toml
- testing was updated to be optional for openai and mistralai
- llm_clients.py was updated to allow for openai and mistralai to not be installed, but throws an ImportError if a user attempts to use a client that they have not installed
- cleaned up some a piece of pydantic that snuck in with the rest of my text generation additions to valor core

I tested with 4 environments, one with both openai and mistralai, one without either, one with openai but not mistralai and one with mistralai and not openai. Tests pass in all cases, although there is an openai test and a mistral test that are skipped now if the corresponding package is not installed.

