### PR TITLE
Allow users to pre-populate joint_df for the Valor text generation streaming manager

### DIFF
--- a/core/valor_core/llm_clients.py
+++ b/core/valor_core/llm_clients.py
@@ -884,7 +884,7 @@ class LLMClient:
         """
         opinions = self._generate_opinions(text)
         if len(opinions) == 0:
-            return 0
+            return 0.0
 
         verdicts = self._generate_bias_verdicts(opinions)
 
@@ -1164,7 +1164,7 @@ class LLMClient:
         """
         opinions = self._generate_opinions(text)
         if len(opinions) == 0:
-            return 0
+            return 0.0
 
         verdicts = self._generate_toxicity_verdicts(opinions)
 


### PR DESCRIPTION
Previously, when the streaming manager was specified, even if the user passed in a joint_df, it would be overwritten with a new empty dataframe with the correct columns. Now, a new empty dataframe is only initialized if no joint_df or an empty joint_df is passed in. The joint_df is also validated, checking that the datum_uids are not null and unique, that either prediction_text or prediction_context_list is not null, and that all the metric values are not null. 

Testing was added in the streaming manager functional test for correct and incorrect joint_df initialization.

Also, edge case return values for Bias and Toxicity were changed from 0 to 0.0, due to a type error that can occur. These metric values are expected to be floats. 