### PR TITLE
Add as_dict to object detection

### DIFF
--- a/lite/tests/detection/test_average_precision.py
+++ b/lite/tests/detection/test_average_precision.py
@@ -98,6 +98,7 @@ def test_ap_metrics(
 
         metrics = evaluator.evaluate(
             iou_thresholds=[0.1, 0.6],
+            as_dict=True,
         )
 
         assert evaluator.ignored_prediction_labels == []
@@ -108,7 +109,7 @@ def test_ap_metrics(
         assert evaluator.n_predictions == 2
 
         # test AP
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+        actual_metrics = [m for m in metrics[MetricType.AP]]
         expected_metrics = [
             {
                 "type": "AP",
@@ -149,7 +150,7 @@ def test_ap_metrics(
             assert m in actual_metrics
 
         # test mAP
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.mAP]]
+        actual_metrics = [m for m in metrics[MetricType.mAP]]
         expected_metrics = [
             {
                 "type": "mAP",
@@ -190,9 +191,7 @@ def test_ap_metrics(
             assert m in actual_metrics
 
         # test AP Averaged Over IoUs
-        actual_metrics = [
-            m.to_dict() for m in metrics[MetricType.APAveragedOverIOUs]
-        ]
+        actual_metrics = [m for m in metrics[MetricType.APAveragedOverIOUs]]
         expected_metrics = [
             {
                 "type": "APAveragedOverIOUs",
@@ -217,9 +216,7 @@ def test_ap_metrics(
             assert m in actual_metrics
 
         # test mAP Averaged Over IoUs
-        actual_metrics = [
-            m.to_dict() for m in metrics[MetricType.mAPAveragedOverIOUs]
-        ]
+        actual_metrics = [m for m in metrics[MetricType.mAPAveragedOverIOUs]]
         expected_metrics = [
             {
                 "type": "mAPAveragedOverIOUs",
@@ -265,10 +262,11 @@ def test_ap_using_torch_metrics_example(
 
     metrics = evaluator.evaluate(
         iou_thresholds=[0.5, 0.75],
+        as_dict=True,
     )
 
     # test AP
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    actual_metrics = [m for m in metrics[MetricType.AP]]
     expected_metrics = [
         {
             "type": "AP",
@@ -357,7 +355,7 @@ def test_ap_using_torch_metrics_example(
         assert m in actual_metrics
 
     # test mAP
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.mAP]]
+    actual_metrics = [m for m in metrics[MetricType.mAP]]
     expected_metrics = [
         {
             "type": "mAP",
@@ -393,9 +391,12 @@ def test_ap_false_negatives_single_datum_baseline(
     loader = DataLoader()
     loader.add_bounding_boxes(false_negatives_single_datum_baseline_detections)
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    actual_metrics = [m for m in metrics[MetricType.AP]]
     expected_metrics = [
         {
             "type": "AP",
@@ -426,9 +427,12 @@ def test_ap_false_negatives_single_datum(
     loader = DataLoader()
     loader.add_bounding_boxes(false_negatives_single_datum_detections)
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    actual_metrics = [m for m in metrics[MetricType.AP]]
     expected_metrics = [
         {
             "type": "AP",
@@ -467,9 +471,12 @@ def test_ap_false_negatives_two_datums_one_empty_low_confidence_of_fp(
         false_negatives_two_datums_one_empty_low_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    actual_metrics = [m for m in metrics[MetricType.AP]]
     expected_metrics = [
         {
             "type": "AP",
@@ -507,9 +514,12 @@ def test_ap_false_negatives_two_datums_one_empty_high_confidence_of_fp(
         false_negatives_two_datums_one_empty_high_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    actual_metrics = [m for m in metrics[MetricType.AP]]
     expected_metrics = [
         {
             "type": "AP",
@@ -547,9 +557,12 @@ def test_ap_false_negatives_two_datums_one_only_with_different_class_low_confide
         false_negatives_two_datums_one_only_with_different_class_low_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    actual_metrics = [m for m in metrics[MetricType.AP]]
     expected_metrics = [
         {
             "type": "AP",
@@ -598,9 +611,12 @@ def test_ap_false_negatives_two_datums_one_only_with_different_class_high_confid
         false_negatives_two_images_one_only_with_different_class_high_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    actual_metrics = [m for m in metrics[MetricType.AP]]
     expected_metrics = [
         {
             "type": "AP",
@@ -662,9 +678,12 @@ def test_ap_ranked_pair_ordering(
             "n_predictions": 4,
         }
 
-        metrics = evaluator.evaluate(iou_thresholds=[0.5, 0.75])
+        metrics = evaluator.evaluate(
+            iou_thresholds=[0.5, 0.75],
+            as_dict=True,
+        )
 
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+        actual_metrics = [m for m in metrics[MetricType.AP]]
         expected_metrics = [
             {
                 "parameters": {
@@ -720,7 +739,7 @@ def test_ap_ranked_pair_ordering(
         for m in expected_metrics:
             assert m in actual_metrics
 
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.mAP]]
+        actual_metrics = [m for m in metrics[MetricType.mAP]]
         expected_metrics = [
             {
                 "parameters": {"label_key": "class", "iou_threshold": 0.5},
@@ -738,9 +757,7 @@ def test_ap_ranked_pair_ordering(
         for m in expected_metrics:
             assert m in actual_metrics
 
-        actual_metrics = [
-            m.to_dict() for m in metrics[MetricType.APAveragedOverIOUs]
-        ]
+        actual_metrics = [m for m in metrics[MetricType.APAveragedOverIOUs]]
         expected_metrics = [
             {
                 "parameters": {
@@ -772,9 +789,7 @@ def test_ap_ranked_pair_ordering(
         for m in expected_metrics:
             assert m in actual_metrics
 
-        actual_metrics = [
-            m.to_dict() for m in metrics[MetricType.mAPAveragedOverIOUs]
-        ]
+        actual_metrics = [m for m in metrics[MetricType.mAPAveragedOverIOUs]]
         expected_metrics = [
             {
                 "parameters": {
@@ -812,12 +827,13 @@ def test_ap_true_positive_deassignment(
     metrics = evaluator.evaluate(
         iou_thresholds=[0.5],
         score_thresholds=[0.5],
+        as_dict=True,
     )
 
     assert len(metrics) == 14
 
     # test AP
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    actual_metrics = [m for m in metrics[MetricType.AP]]
     expected_metrics = [
         {
             "type": "AP",

--- a/lite/tests/detection/test_average_recall.py
+++ b/lite/tests/detection/test_average_recall.py
@@ -102,6 +102,7 @@ def test_ar_metrics(
         metrics = evaluator.evaluate(
             iou_thresholds=[0.1, 0.6],
             score_thresholds=[0.0],
+            as_dict=True,
         )
 
         assert evaluator.ignored_prediction_labels == []
@@ -112,7 +113,7 @@ def test_ar_metrics(
         assert evaluator.n_predictions == 2
 
         # test AR
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.AR]]
+        actual_metrics = [m for m in metrics[MetricType.AR]]
         expected_metrics = [
             {
                 "type": "AR",
@@ -139,7 +140,7 @@ def test_ar_metrics(
             assert m in actual_metrics
 
         # test mAR
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.mAR]]
+        actual_metrics = [m for m in metrics[MetricType.mAR]]
         expected_metrics = [
             {
                 "type": "mAR",
@@ -166,9 +167,7 @@ def test_ar_metrics(
             assert m in actual_metrics
 
         # test AR Averaged Over IoUs
-        actual_metrics = [
-            m.to_dict() for m in metrics[MetricType.ARAveragedOverScores]
-        ]
+        actual_metrics = [m for m in metrics[MetricType.ARAveragedOverScores]]
         expected_metrics = [
             {
                 "type": "ARAveragedOverScores",
@@ -195,9 +194,7 @@ def test_ar_metrics(
             assert m in actual_metrics
 
         # test mAR Averaged Over IoUs
-        actual_metrics = [
-            m.to_dict() for m in metrics[MetricType.mARAveragedOverScores]
-        ]
+        actual_metrics = [m for m in metrics[MetricType.mARAveragedOverScores]]
         expected_metrics = [
             {
                 "type": "mARAveragedOverScores",
@@ -249,10 +246,11 @@ def test_ar_using_torch_metrics_example(
     metrics = evaluator.evaluate(
         iou_thresholds=iou_thresholds,
         score_thresholds=score_thresholds,
+        as_dict=True,
     )
 
     # test AR
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AR]]
+    actual_metrics = [m for m in metrics[MetricType.AR]]
     expected_metrics = [
         {
             "type": "AR",
@@ -306,7 +304,7 @@ def test_ar_using_torch_metrics_example(
         assert m in actual_metrics
 
     # test mAR
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.mAR]]
+    actual_metrics = [m for m in metrics[MetricType.mAR]]
     expected_metrics = [
         {
             "type": "mAR",
@@ -324,9 +322,7 @@ def test_ar_using_torch_metrics_example(
         assert m in actual_metrics
 
     # test ARAveragedOverScores
-    actual_metrics = [
-        m.to_dict() for m in metrics[MetricType.ARAveragedOverScores]
-    ]
+    actual_metrics = [m for m in metrics[MetricType.ARAveragedOverScores]]
     expected_metrics = [
         {
             "type": "ARAveragedOverScores",
@@ -380,9 +376,7 @@ def test_ar_using_torch_metrics_example(
         assert m in actual_metrics
 
     # test mARAveragedOverScores
-    actual_metrics = [
-        m.to_dict() for m in metrics[MetricType.mARAveragedOverScores]
-    ]
+    actual_metrics = [m for m in metrics[MetricType.mARAveragedOverScores]]
     expected_metrics = [
         {
             "type": "mARAveragedOverScores",
@@ -418,12 +412,13 @@ def test_ar_true_positive_deassignment(
     metrics = evaluator.evaluate(
         iou_thresholds=[0.5],
         score_thresholds=[0.5],
+        as_dict=True,
     )
 
     assert len(metrics) == 14
 
     # test AR
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.AR]]
+    actual_metrics = [m for m in metrics[MetricType.AR]]
     expected_metrics = [
         {
             "type": "AR",
@@ -474,10 +469,12 @@ def test_ar_ranked_pair_ordering(
         }
 
         metrics = evaluator.evaluate(
-            iou_thresholds=[0.5, 0.75], score_thresholds=[0.0]
+            iou_thresholds=[0.5, 0.75],
+            score_thresholds=[0.0],
+            as_dict=True,
         )
 
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.AR]]
+        actual_metrics = [m for m in metrics[MetricType.AR]]
         expected_metrics = expected_metrics = [
             {
                 "type": "AR",
@@ -512,7 +509,7 @@ def test_ar_ranked_pair_ordering(
         for m in expected_metrics:
             assert m in actual_metrics
 
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.mAR]]
+        actual_metrics = [m for m in metrics[MetricType.mAR]]
         expected_metrics = expected_metrics = [
             {
                 "type": "mAR",

--- a/lite/tests/detection/test_confusion_matrix.py
+++ b/lite/tests/detection/test_confusion_matrix.py
@@ -441,9 +441,10 @@ def test_confusion_matrix(
         score_thresholds=[0.05, 0.3, 0.35, 0.45, 0.55, 0.95],
         number_of_examples=1,
         metrics_to_return=[MetricType.ConfusionMatrix],
+        as_dict=True,
     )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.ConfusionMatrix]]
+    actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
             "type": "ConfusionMatrix",
@@ -757,9 +758,10 @@ def test_confusion_matrix(
         score_thresholds=[0.05, 0.3, 0.35, 0.45, 0.55, 0.95],
         number_of_examples=1,
         metrics_to_return=[MetricType.ConfusionMatrix],
+        as_dict=True,
     )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.ConfusionMatrix]]
+    actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
             "type": "ConfusionMatrix",
@@ -1129,11 +1131,12 @@ def test_confusion_matrix_using_torch_metrics_example(
         score_thresholds=[0.05, 0.25, 0.35, 0.55, 0.75, 0.8, 0.85, 0.95],
         number_of_examples=0,
         metrics_to_return=[MetricType.ConfusionMatrix],
+        as_dict=True,
     )
 
     assert len(metrics[MetricType.ConfusionMatrix]) == 16
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.ConfusionMatrix]]
+    actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
             "type": "ConfusionMatrix",
@@ -1540,11 +1543,12 @@ def test_confusion_matrix_fp_hallucination_edge_case(
         score_thresholds=[0.5, 0.85],
         number_of_examples=1,
         metrics_to_return=[MetricType.ConfusionMatrix],
+        as_dict=True,
     )
 
     assert len(metrics[MetricType.ConfusionMatrix]) == 2
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.ConfusionMatrix]]
+    actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
             "type": "ConfusionMatrix",
@@ -1667,11 +1671,10 @@ def test_confusion_matrix_ranked_pair_ordering(
             score_thresholds=[0.0],
             number_of_examples=0,
             metrics_to_return=[MetricType.ConfusionMatrix],
+            as_dict=True,
         )
 
-        actual_metrics = [
-            m.to_dict() for m in metrics[MetricType.ConfusionMatrix]
-        ]
+        actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
         expected_metrics = [
             {
                 "type": "ConfusionMatrix",

--- a/lite/tests/detection/test_counts.py
+++ b/lite/tests/detection/test_counts.py
@@ -33,6 +33,7 @@ def test_counts_metrics(
         metrics = evaluator.evaluate(
             iou_thresholds=[0.1, 0.6],
             score_thresholds=[0.0, 0.5],
+            as_dict=True,
         )
 
         assert evaluator.ignored_prediction_labels == []
@@ -43,7 +44,7 @@ def test_counts_metrics(
         assert evaluator.n_predictions == 2
 
         # test Counts
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.Counts]]
+        actual_metrics = [m for m in metrics[MetricType.Counts]]
         expected_metrics = [
             {
                 "type": "Counts",
@@ -169,10 +170,12 @@ def test_counts_false_negatives_single_datum_baseline(
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(
-        iou_thresholds=[0.5], score_thresholds=[0.0, 0.9]
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0, 0.9],
+        as_dict=True,
     )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Counts]]
+    actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
             "type": "Counts",
@@ -224,9 +227,13 @@ def test_counts_false_negatives_single_datum(
     loader = DataLoader()
     loader.add_bounding_boxes(false_negatives_single_datum_detections)
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Counts]]
+    actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
             "type": "Counts",
@@ -270,9 +277,13 @@ def test_counts_false_negatives_two_datums_one_empty_low_confidence_of_fp(
         false_negatives_two_datums_one_empty_low_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Counts]]
+    actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
             "type": "Counts",
@@ -315,9 +326,13 @@ def test_counts_false_negatives_two_datums_one_empty_high_confidence_of_fp(
         false_negatives_two_datums_one_empty_high_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Counts]]
+    actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
             "type": "Counts",
@@ -360,9 +375,13 @@ def test_counts_false_negatives_two_datums_one_only_with_different_class_low_con
         false_negatives_two_datums_one_only_with_different_class_low_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Counts]]
+    actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
             "type": "Counts",
@@ -421,9 +440,13 @@ def test_counts_false_negatives_two_datums_one_only_with_different_class_high_co
         false_negatives_two_images_one_only_with_different_class_high_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Counts]]
+    actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
             "type": "Counts",
@@ -497,10 +520,12 @@ def test_counts_ranked_pair_ordering(
         }
 
         metrics = evaluator.evaluate(
-            iou_thresholds=[0.5, 0.75], score_thresholds=[0.0]
+            iou_thresholds=[0.5, 0.75],
+            score_thresholds=[0.0],
+            as_dict=True,
         )
 
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.Counts]]
+        actual_metrics = [m for m in metrics[MetricType.Counts]]
         expected_metrics = [
             {
                 "type": "Counts",

--- a/lite/tests/detection/test_pr_curve.py
+++ b/lite/tests/detection/test_pr_curve.py
@@ -56,6 +56,7 @@ def test_pr_curve_using_torch_metrics_example(
 
     metrics = evaluator.evaluate(
         iou_thresholds=[0.5, 0.75],
+        as_dict=True,
     )
 
     # AP = 1.0
@@ -86,9 +87,7 @@ def test_pr_curve_using_torch_metrics_example(
     )
 
     # test PrecisionRecallCurve
-    actual_metrics = [
-        m.to_dict() for m in metrics[MetricType.PrecisionRecallCurve]
-    ]
+    actual_metrics = [m for m in metrics[MetricType.PrecisionRecallCurve]]
     expected_metrics = [
         {
             "type": "PrecisionRecallCurve",

--- a/lite/tests/detection/test_precision.py
+++ b/lite/tests/detection/test_precision.py
@@ -32,6 +32,7 @@ def test_precision_metrics(
         metrics = evaluator.evaluate(
             iou_thresholds=[0.1, 0.6],
             score_thresholds=[0.0, 0.5],
+            as_dict=True,
         )
 
         assert evaluator.ignored_prediction_labels == []
@@ -42,7 +43,7 @@ def test_precision_metrics(
         assert evaluator.n_predictions == 2
 
         # test Precision
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+        actual_metrics = [m for m in metrics[MetricType.Precision]]
         expected_metrics = [
             {
                 "type": "Precision",
@@ -136,10 +137,12 @@ def test_precision_false_negatives_single_datum_baseline(
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(
-        iou_thresholds=[0.5], score_thresholds=[0.0, 0.9]
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0, 0.9],
+        as_dict=True,
     )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+    actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
             "type": "Precision",
@@ -183,9 +186,13 @@ def test_precision_false_negatives_single_datum(
     loader = DataLoader()
     loader.add_bounding_boxes(false_negatives_single_datum_detections)
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+    actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
             "type": "Precision",
@@ -225,9 +232,13 @@ def test_precision_false_negatives_two_datums_one_empty_low_confidence_of_fp(
         false_negatives_two_datums_one_empty_low_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+    actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
             "type": "Precision",
@@ -266,9 +277,13 @@ def test_precision_false_negatives_two_datums_one_empty_high_confidence_of_fp(
         false_negatives_two_datums_one_empty_high_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+    actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
             "type": "Precision",
@@ -307,9 +322,13 @@ def test_precision_false_negatives_two_datums_one_only_with_different_class_low_
         false_negatives_two_datums_one_only_with_different_class_low_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+    actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
             "type": "Precision",
@@ -360,9 +379,13 @@ def test_precision_false_negatives_two_datums_one_only_with_different_class_high
         false_negatives_two_images_one_only_with_different_class_high_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+    actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
             "type": "Precision",

--- a/lite/tests/detection/test_recall.py
+++ b/lite/tests/detection/test_recall.py
@@ -32,6 +32,7 @@ def test_recall_metrics(
         metrics = evaluator.evaluate(
             iou_thresholds=[0.1, 0.6],
             score_thresholds=[0.0, 0.5],
+            as_dict=True,
         )
 
         assert evaluator.ignored_prediction_labels == []
@@ -42,7 +43,7 @@ def test_recall_metrics(
         assert evaluator.n_predictions == 2
 
         # test Recall
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.Recall]]
+        actual_metrics = [m for m in metrics[MetricType.Recall]]
         expected_metrics = [
             {
                 "type": "Recall",
@@ -136,10 +137,12 @@ def test_recall_false_negatives_single_datum_baseline(
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(
-        iou_thresholds=[0.5], score_thresholds=[0.0, 0.9]
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0, 0.9],
+        as_dict=True,
     )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Recall]]
+    actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
             "type": "Recall",
@@ -183,9 +186,13 @@ def test_recall_false_negatives_single_datum(
     loader = DataLoader()
     loader.add_bounding_boxes(false_negatives_single_datum_detections)
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Recall]]
+    actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
             "type": "Recall",
@@ -225,9 +232,13 @@ def test_recall_false_negatives_two_datums_one_empty_low_confidence_of_fp(
         false_negatives_two_datums_one_empty_low_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Recall]]
+    actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
             "type": "Recall",
@@ -266,9 +277,13 @@ def test_recall_false_negatives_two_datums_one_empty_high_confidence_of_fp(
         false_negatives_two_datums_one_empty_high_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Recall]]
+    actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
             "type": "Recall",
@@ -307,9 +322,13 @@ def test_recall_false_negatives_two_datums_one_only_with_different_class_low_con
         false_negatives_two_datums_one_only_with_different_class_low_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Recall]]
+    actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
             "type": "Recall",
@@ -360,9 +379,13 @@ def test_recall_false_negatives_two_datums_one_only_with_different_class_high_co
         false_negatives_two_images_one_only_with_different_class_high_confidence_of_fp_detections
     )
     evaluator = loader.finalize()
-    metrics = evaluator.evaluate(iou_thresholds=[0.5], score_thresholds=[0.0])
+    metrics = evaluator.evaluate(
+        iou_thresholds=[0.5],
+        score_thresholds=[0.0],
+        as_dict=True,
+    )
 
-    actual_metrics = [m.to_dict() for m in metrics[MetricType.Recall]]
+    actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
             "type": "Recall",

--- a/lite/valor_lite/classification/manager.py
+++ b/lite/valor_lite/classification/manager.py
@@ -241,6 +241,8 @@ class Evaluator:
             Maximum number of annotation examples to return in ConfusionMatrix.
         filter_ : Filter, optional
             An optional filter object.
+        as_dict : bool, default=False
+            An option to return metrics as dictionaries.
 
         Returns
         -------

--- a/lite/valor_lite/detection/manager.py
+++ b/lite/valor_lite/detection/manager.py
@@ -342,6 +342,7 @@ class Evaluator:
         score_thresholds: list[float] = [0.5],
         number_of_examples: int = 0,
         filter_: Filter | None = None,
+        as_dict: bool = False,
     ) -> dict[MetricType, list]:
         """
         Performs an evaluation and returns metrics.
@@ -358,6 +359,8 @@ class Evaluator:
             Maximum number of annotation examples to return in ConfusionMatrix.
         filter_ : Filter, optional
             An optional filter object.
+        as_dict : bool, default=False
+            An option to return metrics as dictionaries.
 
         Returns
         -------
@@ -558,6 +561,12 @@ class Evaluator:
         for metric in set(metrics.keys()):
             if metric not in metrics_to_return:
                 del metrics[metric]
+
+        if as_dict:
+            return {
+                mtype: [metric.to_dict() for metric in mvalues]
+                for mtype, mvalues in metrics.items()
+            }
 
         return metrics
 


### PR DESCRIPTION
# Changes
- Added the `as_dict` parameter to object detections `evaluate` call. This is a short cut for converting all metrics to generic dictionaries.