### PR TITLE
Remove label keys from `lite` detections

### DIFF
--- a/integration_tests/benchmarks/classification/benchmark_script.py
+++ b/integration_tests/benchmarks/classification/benchmark_script.py
@@ -299,9 +299,10 @@ def run_benchmarking_analysis(
         eval_pr = run_pr_curve_evaluation(
             dset=dset, model=model, timeout=evaluation_timeout
         )
-        eval_detail = run_detailed_pr_curve_evaluation(
-            dset=dset, model=model, timeout=evaluation_timeout
-        )
+        # NOTE: turned this off due to long runtimes causing TimeoutError
+        # eval_detail = run_detailed_pr_curve_evaluation(
+        #     dset=dset, model=model, timeout=evaluation_timeout
+        # )
 
         # delete model
         start = time.time()
@@ -331,7 +332,7 @@ def run_benchmarking_analysis(
                 n_labels=eval_base.meta["labels"],
                 eval_base=eval_base.meta["duration"],
                 eval_base_pr=eval_pr.meta["duration"],
-                eval_base_pr_detail=eval_detail.meta["duration"],
+                eval_base_pr_detail=-1,
             ).result()
         )
 

--- a/integration_tests/benchmarks/classification/benchmark_script.py
+++ b/integration_tests/benchmarks/classification/benchmark_script.py
@@ -332,7 +332,7 @@ def run_benchmarking_analysis(
                 n_labels=eval_base.meta["labels"],
                 eval_base=eval_base.meta["duration"],
                 eval_base_pr=eval_pr.meta["duration"],
-                eval_base_pr_detail=-1,
+                eval_base_pr_detail=-1,  # eval_detail.meta["duration"],
             ).result()
         )
 

--- a/integration_tests/benchmarks/object-detection/benchmark_script.py
+++ b/integration_tests/benchmarks/object-detection/benchmark_script.py
@@ -301,8 +301,8 @@ def run_benchmarking_analysis(
     chunk_size: int = -1,
     ingestion_timeout: int = 30,
     evaluation_timeout: int = 30,
-    compute_pr: bool = True,
-    compute_detailed: bool = True,
+    compute_pr: bool = False,
+    compute_detailed: bool = False,
 ):
     """Time various function calls and export the results."""
     current_directory = Path(__file__).parent

--- a/integration_tests/benchmarks/object-detection/benchmark_script.py
+++ b/integration_tests/benchmarks/object-detection/benchmark_script.py
@@ -245,48 +245,52 @@ class Benchmark:
                     "model": f"{round(self.pd_deletion, 2)} seconds",
                 },
             },
-            "base+pr": {
-                "ingestion": {
-                    "dataset": f"{round(self.gt_ingest, 2)} seconds",
-                    "model": f"{round(self.pd_ingest, 2)} seconds",
-                },
-                "finalization": {
-                    "dataset": f"{round(self.gt_finalization, 2)} seconds",
-                    "model": f"{round(self.pd_finalization, 2)} seconds",
-                },
-                "evaluation": {
-                    "preprocessing": "0.0 seconds",
-                    "computation": f"{round(self.eval_base_pr, 2)} seconds",
-                    "total": f"{round(self.eval_base_pr, 2)} seconds",
-                },
-                "deletion": {
-                    "dataset": f"{round(self.gt_deletion, 2)} seconds",
-                    "model": f"{round(self.pd_deletion, 2)} seconds",
-                },
-            }
-            if self.eval_base_pr > -1
-            else {},
-            "base+pr+detailed": {
-                "ingestion": {
-                    "dataset": f"{round(self.gt_ingest, 2)} seconds",
-                    "model": f"{round(self.pd_ingest, 2)} seconds",
-                },
-                "finalization": {
-                    "dataset": f"{round(self.gt_finalization, 2)} seconds",
-                    "model": f"{round(self.pd_finalization, 2)} seconds",
-                },
-                "evaluation": {
-                    "preprocessing": "0.0 seconds",
-                    "computation": f"{round(self.eval_base_pr_detail, 2)} seconds",
-                    "total": f"{round(self.eval_base_pr_detail, 2)} seconds",
-                },
-                "deletion": {
-                    "dataset": f"{round(self.gt_deletion, 2)} seconds",
-                    "model": f"{round(self.pd_deletion, 2)} seconds",
-                },
-            }
-            if self.eval_base_pr_detail > -1
-            else {},
+            "base+pr": (
+                {
+                    "ingestion": {
+                        "dataset": f"{round(self.gt_ingest, 2)} seconds",
+                        "model": f"{round(self.pd_ingest, 2)} seconds",
+                    },
+                    "finalization": {
+                        "dataset": f"{round(self.gt_finalization, 2)} seconds",
+                        "model": f"{round(self.pd_finalization, 2)} seconds",
+                    },
+                    "evaluation": {
+                        "preprocessing": "0.0 seconds",
+                        "computation": f"{round(self.eval_base_pr, 2)} seconds",
+                        "total": f"{round(self.eval_base_pr, 2)} seconds",
+                    },
+                    "deletion": {
+                        "dataset": f"{round(self.gt_deletion, 2)} seconds",
+                        "model": f"{round(self.pd_deletion, 2)} seconds",
+                    },
+                }
+                if self.eval_base_pr > -1
+                else {}
+            ),
+            "base+pr+detailed": (
+                {
+                    "ingestion": {
+                        "dataset": f"{round(self.gt_ingest, 2)} seconds",
+                        "model": f"{round(self.pd_ingest, 2)} seconds",
+                    },
+                    "finalization": {
+                        "dataset": f"{round(self.gt_finalization, 2)} seconds",
+                        "model": f"{round(self.pd_finalization, 2)} seconds",
+                    },
+                    "evaluation": {
+                        "preprocessing": "0.0 seconds",
+                        "computation": f"{round(self.eval_base_pr_detail, 2)} seconds",
+                        "total": f"{round(self.eval_base_pr_detail, 2)} seconds",
+                    },
+                    "deletion": {
+                        "dataset": f"{round(self.gt_deletion, 2)} seconds",
+                        "model": f"{round(self.pd_deletion, 2)} seconds",
+                    },
+                }
+                if self.eval_base_pr_detail > -1
+                else {}
+            ),
         }
 
 

--- a/integration_tests/benchmarks/object-detection/benchmark_script.py
+++ b/integration_tests/benchmarks/object-detection/benchmark_script.py
@@ -245,52 +245,48 @@ class Benchmark:
                     "model": f"{round(self.pd_deletion, 2)} seconds",
                 },
             },
-            "base+pr": (
-                {
-                    "ingestion": {
-                        "dataset": f"{round(self.gt_ingest, 2)} seconds",
-                        "model": f"{round(self.pd_ingest, 2)} seconds",
-                    },
-                    "finalization": {
-                        "dataset": f"{round(self.gt_finalization, 2)} seconds",
-                        "model": f"{round(self.pd_finalization, 2)} seconds",
-                    },
-                    "evaluation": {
-                        "preprocessing": "0.0 seconds",
-                        "computation": f"{round(self.eval_base_pr, 2)} seconds",
-                        "total": f"{round(self.eval_base_pr, 2)} seconds",
-                    },
-                    "deletion": {
-                        "dataset": f"{round(self.gt_deletion, 2)} seconds",
-                        "model": f"{round(self.pd_deletion, 2)} seconds",
-                    },
-                }
-                if self.eval_base_pr > -1
-                else {}
-            ),
-            "base+pr+detailed": (
-                {
-                    "ingestion": {
-                        "dataset": f"{round(self.gt_ingest, 2)} seconds",
-                        "model": f"{round(self.pd_ingest, 2)} seconds",
-                    },
-                    "finalization": {
-                        "dataset": f"{round(self.gt_finalization, 2)} seconds",
-                        "model": f"{round(self.pd_finalization, 2)} seconds",
-                    },
-                    "evaluation": {
-                        "preprocessing": "0.0 seconds",
-                        "computation": f"{round(self.eval_base_pr_detail, 2)} seconds",
-                        "total": f"{round(self.eval_base_pr_detail, 2)} seconds",
-                    },
-                    "deletion": {
-                        "dataset": f"{round(self.gt_deletion, 2)} seconds",
-                        "model": f"{round(self.pd_deletion, 2)} seconds",
-                    },
-                }
-                if self.eval_base_pr_detail > -1
-                else {}
-            ),
+            "base+pr": {
+                "ingestion": {
+                    "dataset": f"{round(self.gt_ingest, 2)} seconds",
+                    "model": f"{round(self.pd_ingest, 2)} seconds",
+                },
+                "finalization": {
+                    "dataset": f"{round(self.gt_finalization, 2)} seconds",
+                    "model": f"{round(self.pd_finalization, 2)} seconds",
+                },
+                "evaluation": {
+                    "preprocessing": "0.0 seconds",
+                    "computation": f"{round(self.eval_base_pr, 2)} seconds",
+                    "total": f"{round(self.eval_base_pr, 2)} seconds",
+                },
+                "deletion": {
+                    "dataset": f"{round(self.gt_deletion, 2)} seconds",
+                    "model": f"{round(self.pd_deletion, 2)} seconds",
+                },
+            }
+            if self.eval_base_pr > -1
+            else {},
+            "base+pr+detailed": {
+                "ingestion": {
+                    "dataset": f"{round(self.gt_ingest, 2)} seconds",
+                    "model": f"{round(self.pd_ingest, 2)} seconds",
+                },
+                "finalization": {
+                    "dataset": f"{round(self.gt_finalization, 2)} seconds",
+                    "model": f"{round(self.pd_finalization, 2)} seconds",
+                },
+                "evaluation": {
+                    "preprocessing": "0.0 seconds",
+                    "computation": f"{round(self.eval_base_pr_detail, 2)} seconds",
+                    "total": f"{round(self.eval_base_pr_detail, 2)} seconds",
+                },
+                "deletion": {
+                    "dataset": f"{round(self.gt_deletion, 2)} seconds",
+                    "model": f"{round(self.pd_deletion, 2)} seconds",
+                },
+            }
+            if self.eval_base_pr_detail > -1
+            else {},
         }
 
 

--- a/lite/tests/detection/conftest.py
+++ b/lite/tests/detection/conftest.py
@@ -71,10 +71,9 @@ def rect3_rotated_5_degrees_around_origin() -> list[tuple[float, float]]:
 
 
 @pytest.fixture
-def basic_detections(
+def basic_detections_first_class(
     rect1: tuple[float, float, float, float],
     rect2: tuple[float, float, float, float],
-    rect3: tuple[float, float, float, float],
 ) -> list[Detection]:
     return [
         Detection(
@@ -85,14 +84,7 @@ def basic_detections(
                     xmax=rect1[1],
                     ymin=rect1[2],
                     ymax=rect1[3],
-                    labels=[("k1", "v1")],
-                ),
-                BoundingBox(
-                    xmin=rect3[0],
-                    xmax=rect3[1],
-                    ymin=rect3[2],
-                    ymax=rect3[3],
-                    labels=[("k2", "v2")],
+                    labels=["v1"],
                 ),
             ],
             predictions=[
@@ -101,7 +93,7 @@ def basic_detections(
                     xmax=rect1[1],
                     ymin=rect1[2],
                     ymax=rect1[3],
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.3],
                 ),
             ],
@@ -114,16 +106,43 @@ def basic_detections(
                     xmax=rect2[1],
                     ymin=rect2[2],
                     ymax=rect2[3],
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                 ),
             ],
+            predictions=[],
+        ),
+    ]
+
+
+@pytest.fixture
+def basic_detections_second_class(
+    rect2: tuple[float, float, float, float],
+    rect3: tuple[float, float, float, float],
+) -> list[Detection]:
+    return [
+        Detection(
+            uid="uid1",
+            groundtruths=[
+                BoundingBox(
+                    xmin=rect3[0],
+                    xmax=rect3[1],
+                    ymin=rect3[2],
+                    ymax=rect3[3],
+                    labels=["v2"],
+                ),
+            ],
+            predictions=[],
+        ),
+        Detection(
+            uid="uid2",
+            groundtruths=[],
             predictions=[
                 BoundingBox(
                     xmin=rect2[0],
                     xmax=rect2[1],
                     ymin=rect2[2],
                     ymax=rect2[3],
-                    labels=[("k2", "v2")],
+                    labels=["v2"],
                     scores=[0.98],
                 ),
             ],
@@ -132,8 +151,48 @@ def basic_detections(
 
 
 @pytest.fixture
-def basic_rotated_detections(
+def basic_rotated_detections_first_class(
     rect1_rotated_5_degrees_around_origin: tuple[float, float, float, float],
+    rect2_rotated_5_degrees_around_origin: tuple[float, float, float, float],
+) -> list[Detection]:
+    return [
+        Detection(
+            uid="uid1",
+            groundtruths=[
+                Polygon(
+                    shape=ShapelyPolygon(
+                        rect1_rotated_5_degrees_around_origin
+                    ),
+                    labels=["v1"],
+                ),
+            ],
+            predictions=[
+                Polygon(
+                    shape=ShapelyPolygon(
+                        rect1_rotated_5_degrees_around_origin
+                    ),
+                    labels=["v1"],
+                    scores=[0.3],
+                ),
+            ],
+        ),
+        Detection(
+            uid="uid2",
+            groundtruths=[
+                Polygon(
+                    shape=ShapelyPolygon(
+                        rect2_rotated_5_degrees_around_origin
+                    ),
+                    labels=["v1"],
+                ),
+            ],
+            predictions=[],
+        ),
+    ]
+
+
+@pytest.fixture
+def basic_rotated_detections_second_class(
     rect2_rotated_5_degrees_around_origin: tuple[float, float, float, float],
     rect3_rotated_5_degrees_around_origin: tuple[float, float, float, float],
 ) -> list[Detection]:
@@ -143,43 +202,22 @@ def basic_rotated_detections(
             groundtruths=[
                 Polygon(
                     shape=ShapelyPolygon(
-                        rect1_rotated_5_degrees_around_origin
-                    ),
-                    labels=[("k1", "v1")],
-                ),
-                Polygon(
-                    shape=ShapelyPolygon(
                         rect3_rotated_5_degrees_around_origin
                     ),
-                    labels=[("k2", "v2")],
+                    labels=["v2"],
                 ),
             ],
-            predictions=[
-                Polygon(
-                    shape=ShapelyPolygon(
-                        rect1_rotated_5_degrees_around_origin
-                    ),
-                    labels=[("k1", "v1")],
-                    scores=[0.3],
-                ),
-            ],
+            predictions=[],
         ),
         Detection(
             uid="uid2",
-            groundtruths=[
-                Polygon(
-                    shape=ShapelyPolygon(
-                        rect2_rotated_5_degrees_around_origin
-                    ),
-                    labels=[("k1", "v1")],
-                ),
-            ],
+            groundtruths=[],
             predictions=[
                 Polygon(
                     shape=ShapelyPolygon(
                         rect2_rotated_5_degrees_around_origin
                     ),
-                    labels=[("k2", "v2")],
+                    labels=["v2"],
                     scores=[0.98],
                 ),
             ],
@@ -308,7 +346,7 @@ def torchmetrics_detections() -> list[Detection]:
                     ymin=box[1],
                     xmax=box[2],
                     ymax=box[3],
-                    labels=[("class", label_value)],
+                    labels=[label_value],
                 )
                 for box, label_value in zip(gt["boxes"], gt["labels"])
             ],
@@ -318,7 +356,7 @@ def torchmetrics_detections() -> list[Detection]:
                     ymin=box[1],
                     xmax=box[2],
                     ymax=box[3],
-                    labels=[("class", label_value)],
+                    labels=[label_value],
                     scores=[score],
                 )
                 for box, label_value, score in zip(
@@ -341,7 +379,7 @@ def false_negatives_single_datum_baseline_detections() -> list[Detection]:
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                 )
             ],
             predictions=[
@@ -350,7 +388,7 @@ def false_negatives_single_datum_baseline_detections() -> list[Detection]:
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.8],
                 ),
                 BoundingBox(
@@ -358,7 +396,7 @@ def false_negatives_single_datum_baseline_detections() -> list[Detection]:
                     xmax=110,
                     ymin=100,
                     ymax=200,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.7],
                 ),
             ],
@@ -377,7 +415,7 @@ def false_negatives_single_datum_detections() -> list[Detection]:
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                 )
             ],
             predictions=[
@@ -386,7 +424,7 @@ def false_negatives_single_datum_detections() -> list[Detection]:
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.8],
                 ),
                 BoundingBox(
@@ -394,7 +432,7 @@ def false_negatives_single_datum_detections() -> list[Detection]:
                     xmax=110,
                     ymin=100,
                     ymax=200,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.9],
                 ),
             ],
@@ -416,7 +454,7 @@ def false_negatives_two_datums_one_empty_low_confidence_of_fp_detections() -> (
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                 )
             ],
             predictions=[
@@ -425,7 +463,7 @@ def false_negatives_two_datums_one_empty_low_confidence_of_fp_detections() -> (
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.8],
                 ),
             ],
@@ -439,7 +477,7 @@ def false_negatives_two_datums_one_empty_low_confidence_of_fp_detections() -> (
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.7],
                 ),
             ],
@@ -461,7 +499,7 @@ def false_negatives_two_datums_one_empty_high_confidence_of_fp_detections() -> (
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                 )
             ],
             predictions=[
@@ -470,7 +508,7 @@ def false_negatives_two_datums_one_empty_high_confidence_of_fp_detections() -> (
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.8],
                 ),
             ],
@@ -484,7 +522,7 @@ def false_negatives_two_datums_one_empty_high_confidence_of_fp_detections() -> (
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.9],
                 ),
             ],
@@ -506,7 +544,7 @@ def false_negatives_two_datums_one_only_with_different_class_low_confidence_of_f
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                 )
             ],
             predictions=[
@@ -515,7 +553,7 @@ def false_negatives_two_datums_one_only_with_different_class_low_confidence_of_f
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.8],
                 ),
             ],
@@ -528,7 +566,7 @@ def false_negatives_two_datums_one_only_with_different_class_low_confidence_of_f
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "other value")],
+                    labels=["other_value"],
                 )
             ],
             predictions=[
@@ -537,7 +575,7 @@ def false_negatives_two_datums_one_only_with_different_class_low_confidence_of_f
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.7],
                 ),
             ],
@@ -559,7 +597,7 @@ def false_negatives_two_images_one_only_with_different_class_high_confidence_of_
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                 )
             ],
             predictions=[
@@ -568,7 +606,7 @@ def false_negatives_two_images_one_only_with_different_class_high_confidence_of_
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.8],
                 ),
             ],
@@ -581,7 +619,7 @@ def false_negatives_two_images_one_only_with_different_class_high_confidence_of_
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "other value")],
+                    labels=["other_value"],
                 )
             ],
             predictions=[
@@ -590,7 +628,7 @@ def false_negatives_two_images_one_only_with_different_class_high_confidence_of_
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("key", "value")],
+                    labels=["value"],
                     scores=[0.9],
                 ),
             ],
@@ -609,7 +647,7 @@ def detections_fp_hallucination_edge_case() -> list[Detection]:
                     xmax=5,
                     ymin=0,
                     ymax=5,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                 )
             ],
             predictions=[
@@ -618,7 +656,7 @@ def detections_fp_hallucination_edge_case() -> list[Detection]:
                     xmax=5,
                     ymin=0,
                     ymax=5,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.8],
                 )
             ],
@@ -631,7 +669,7 @@ def detections_fp_hallucination_edge_case() -> list[Detection]:
                     xmax=5,
                     ymin=0,
                     ymax=5,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                 )
             ],
             predictions=[
@@ -640,7 +678,7 @@ def detections_fp_hallucination_edge_case() -> list[Detection]:
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.8],
                 )
             ],
@@ -659,14 +697,14 @@ def detections_tp_deassignment_edge_case() -> list[Detection]:
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                 ),
                 BoundingBox(
                     xmin=10,
                     xmax=15,
                     ymin=20,
                     ymax=25,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                 ),
             ],
             predictions=[
@@ -675,7 +713,7 @@ def detections_tp_deassignment_edge_case() -> list[Detection]:
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.78],
                 ),
                 BoundingBox(
@@ -683,7 +721,7 @@ def detections_tp_deassignment_edge_case() -> list[Detection]:
                     xmax=20,
                     ymin=12,
                     ymax=22,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.96],
                 ),
                 BoundingBox(
@@ -691,7 +729,7 @@ def detections_tp_deassignment_edge_case() -> list[Detection]:
                     xmax=20,
                     ymin=12,
                     ymax=22,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.96],
                 ),
                 BoundingBox(
@@ -699,7 +737,7 @@ def detections_tp_deassignment_edge_case() -> list[Detection]:
                     xmax=102,
                     ymin=101,
                     ymax=102,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.87],
                 ),
             ],
@@ -742,7 +780,7 @@ def detection_ranked_pair_ordering() -> Detection:
             xmax=xmax,
             ymin=ymin,
             ymax=ymax,
-            labels=[("class", label_value)],
+            labels=[label_value],
         )
         for (xmin, xmax, ymin, ymax), label_value in zip(
             gts["boxes"], gts["label_values"]
@@ -755,7 +793,7 @@ def detection_ranked_pair_ordering() -> Detection:
             xmax=xmax,
             ymin=ymin,
             ymax=ymax,
-            labels=[("class", label_value)],
+            labels=[label_value],
             scores=[score],
         )
         for (xmin, xmax, ymin, ymax), label_value, score in zip(
@@ -799,7 +837,7 @@ def detection_ranked_pair_ordering_with_bitmasks() -> Detection:
     groundtruths = [
         Bitmask(
             mask=mask,
-            labels=[("class", label_value)],
+            labels=[label_value],
         )
         for mask, label_value in zip(gts["bitmasks"], gts["label_values"])
     ]
@@ -807,7 +845,7 @@ def detection_ranked_pair_ordering_with_bitmasks() -> Detection:
     predictions = [
         Bitmask(
             mask=mask,
-            labels=[("class", label_value)],
+            labels=[label_value],
             scores=[score],
         )
         for mask, label_value, score in zip(
@@ -854,7 +892,7 @@ def detection_ranked_pair_ordering_with_polygons(
     groundtruths = [
         Polygon(
             shape=ShapelyPolygon(polygon),
-            labels=[("class", label_value)],
+            labels=[label_value],
         )
         for polygon, label_value in zip(gts["polygons"], gts["label_values"])
     ]
@@ -862,7 +900,7 @@ def detection_ranked_pair_ordering_with_polygons(
     predictions = [
         Polygon(
             shape=ShapelyPolygon(polygon),
-            labels=[("class", label_value)],
+            labels=[label_value],
             scores=[score],
         )
         for polygon, label_value, score in zip(
@@ -887,15 +925,7 @@ def detections_no_groundtruths() -> list[Detection]:
                     xmax=10,
                     ymin=0,
                     ymax=10,
-                    labels=[("k1", "v1")],
-                    scores=[1.0],
-                ),
-                BoundingBox(
-                    xmin=0,
-                    xmax=10,
-                    ymin=0,
-                    ymax=10,
-                    labels=[("k2", "v2")],
+                    labels=["v1"],
                     scores=[1.0],
                 ),
             ],
@@ -909,7 +939,7 @@ def detections_no_groundtruths() -> list[Detection]:
                     xmax=10,
                     ymin=0,
                     ymax=10,
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[1.0],
                 ),
             ],
@@ -923,21 +953,14 @@ def detections_no_predictions() -> list[Detection]:
         Detection(
             uid="uid",
             groundtruths=[
-                BoundingBox(
-                    xmin=0, xmax=10, ymin=0, ymax=10, labels=[("k1", "v1")]
-                ),
-                BoundingBox(
-                    xmin=0, xmax=10, ymin=0, ymax=10, labels=[("k2", "v2")]
-                ),
+                BoundingBox(xmin=0, xmax=10, ymin=0, ymax=10, labels=["v1"]),
             ],
             predictions=[],
         ),
         Detection(
             uid="uid",
             groundtruths=[
-                BoundingBox(
-                    xmin=0, xmax=10, ymin=0, ymax=10, labels=[("k1", "v1")]
-                ),
+                BoundingBox(xmin=0, xmax=10, ymin=0, ymax=10, labels=["v1"]),
             ],
             predictions=[],
         ),
@@ -962,21 +985,21 @@ def detections_for_detailed_counting(
                     xmax=rect1[1],
                     ymin=rect1[2],
                     ymax=rect1[3],
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                 ),
                 BoundingBox(
                     xmin=rect2[0],
                     xmax=rect2[1],
                     ymin=rect2[2],
                     ymax=rect2[3],
-                    labels=[("k1", "missed_detection")],
+                    labels=["missed_detection"],
                 ),
                 BoundingBox(
                     xmin=rect3[0],
                     xmax=rect3[1],
                     ymin=rect3[2],
                     ymax=rect3[3],
-                    labels=[("k1", "v2")],
+                    labels=["v2"],
                 ),
             ],
             predictions=[
@@ -985,7 +1008,7 @@ def detections_for_detailed_counting(
                     xmax=rect1[1],
                     ymin=rect1[2],
                     ymax=rect1[3],
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.5],
                 ),
                 BoundingBox(
@@ -993,7 +1016,7 @@ def detections_for_detailed_counting(
                     xmax=rect5[1],
                     ymin=rect5[2],
                     ymax=rect5[3],
-                    labels=[("k1", "not_v2")],
+                    labels=["not_v2"],
                     scores=[0.3],
                 ),
                 BoundingBox(
@@ -1001,7 +1024,7 @@ def detections_for_detailed_counting(
                     xmax=rect4[1],
                     ymin=rect4[2],
                     ymax=rect4[3],
-                    labels=[("k1", "hallucination")],
+                    labels=["hallucination"],
                     scores=[0.1],
                 ),
             ],
@@ -1014,7 +1037,7 @@ def detections_for_detailed_counting(
                     xmax=rect1[1],
                     ymin=rect1[2],
                     ymax=rect1[3],
-                    labels=[("k1", "low_iou")],
+                    labels=["low_iou"],
                 ),
             ],
             predictions=[
@@ -1023,7 +1046,7 @@ def detections_for_detailed_counting(
                     xmax=rect2[1],
                     ymin=rect2[2],
                     ymax=rect2[3],
-                    labels=[("k1", "low_iou")],
+                    labels=["low_iou"],
                     scores=[0.5],
                 ),
             ],

--- a/lite/tests/detection/conftest.py
+++ b/lite/tests/detection/conftest.py
@@ -151,6 +151,68 @@ def basic_detections_second_class(
 
 
 @pytest.fixture
+def basic_detections(
+    rect1: tuple[float, float, float, float],
+    rect2: tuple[float, float, float, float],
+    rect3: tuple[float, float, float, float],
+) -> list[Detection]:
+    """Combines the labels from basic_detections_first_class and basic_detections_second_class."""
+    return [
+        Detection(
+            uid="uid1",
+            groundtruths=[
+                BoundingBox(
+                    xmin=rect1[0],
+                    xmax=rect1[1],
+                    ymin=rect1[2],
+                    ymax=rect1[3],
+                    labels=["v1"],
+                ),
+                BoundingBox(
+                    xmin=rect3[0],
+                    xmax=rect3[1],
+                    ymin=rect3[2],
+                    ymax=rect3[3],
+                    labels=["v2"],
+                ),
+            ],
+            predictions=[
+                BoundingBox(
+                    xmin=rect1[0],
+                    xmax=rect1[1],
+                    ymin=rect1[2],
+                    ymax=rect1[3],
+                    labels=["v1"],
+                    scores=[0.3],
+                ),
+            ],
+        ),
+        Detection(
+            uid="uid2",
+            groundtruths=[
+                BoundingBox(
+                    xmin=rect2[0],
+                    xmax=rect2[1],
+                    ymin=rect2[2],
+                    ymax=rect2[3],
+                    labels=["v1"],
+                ),
+            ],
+            predictions=[
+                BoundingBox(
+                    xmin=rect2[0],
+                    xmax=rect2[1],
+                    ymin=rect2[2],
+                    ymax=rect2[3],
+                    labels=["v2"],
+                    scores=[0.98],
+                ),
+            ],
+        ),
+    ]
+
+
+@pytest.fixture
 def basic_rotated_detections_first_class(
     rect1_rotated_5_degrees_around_origin: tuple[float, float, float, float],
     rect2_rotated_5_degrees_around_origin: tuple[float, float, float, float],

--- a/lite/tests/detection/conftest.py
+++ b/lite/tests/detection/conftest.py
@@ -566,7 +566,7 @@ def false_negatives_two_datums_one_only_with_different_class_low_confidence_of_f
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=["other_value"],
+                    labels=["other value"],
                 )
             ],
             predictions=[
@@ -619,7 +619,7 @@ def false_negatives_two_images_one_only_with_different_class_high_confidence_of_
                     xmax=20,
                     ymin=10,
                     ymax=20,
-                    labels=["other_value"],
+                    labels=["other value"],
                 )
             ],
             predictions=[

--- a/lite/tests/detection/test_average_precision.py
+++ b/lite/tests/detection/test_average_precision.py
@@ -24,12 +24,7 @@ def test__compute_average_precision():
     iou_thresholds = np.array([0.1, 0.6])
     score_thresholds = np.array([0.0])
 
-    (
-        results,
-        _,
-        _,
-        _,
-    ) = compute_metrics(
+    (results, _, _, _,) = compute_metrics(
         sorted_pairs,
         label_metadata=label_metadata,
         iou_thresholds=iou_thresholds,
@@ -42,26 +37,26 @@ def test__compute_average_precision():
         mean_average_precision_averaged_over_ious,
     ) = results
 
-    expected_ap = np.array(
+    expected = np.array(
         [
             [1.0],  # iou = 0.1
             [1 / 3],  # iou = 0.6
         ]
     )
-    assert expected_ap.shape == average_precision.shape
-    assert np.isclose(average_precision, expected_ap).all()
+    assert expected.shape == average_precision.shape
+    assert np.isclose(average_precision, expected).all()
 
-    assert expected_ap.flatten().shape == mean_average_precision.shape
-    assert np.isclose(mean_average_precision, expected_ap.flatten()).all()
+    assert expected.flatten().shape == mean_average_precision.shape
+    assert np.isclose(mean_average_precision, expected.flatten()).all()
 
-    expected_ar = np.array([2 / 3])
+    expected = np.array([2 / 3])
 
-    assert average_precision_averaged_over_ious.shape == expected_ar.shape
-    assert np.isclose(average_precision_averaged_over_ious, expected_ar).all()
+    assert average_precision_averaged_over_ious.shape == expected.shape
+    assert np.isclose(average_precision_averaged_over_ious, expected).all()
 
     assert isinstance(mean_average_precision_averaged_over_ious, float)
     assert np.isclose(
-        mean_average_precision_averaged_over_ious, expected_ar.flatten()
+        mean_average_precision_averaged_over_ious, expected.flatten()
     ).all()
 
 
@@ -597,7 +592,7 @@ def test_ap_false_negatives_two_datums_one_only_with_different_class_low_confide
         {
             "type": "AP",
             "value": 0.0,
-            "parameters": {"iou_threshold": 0.5, "label": "other_value"},
+            "parameters": {"iou_threshold": 0.5, "label": "other value"},
         },
     ]
     for m in actual_metrics:
@@ -636,7 +631,7 @@ def test_ap_false_negatives_two_datums_one_only_with_different_class_high_confid
         {
             "type": "AP",
             "value": 0.0,
-            "parameters": {"iou_threshold": 0.5, "label": "other_value"},
+            "parameters": {"iou_threshold": 0.5, "label": "other value"},
         },
     ]
     for m in actual_metrics:

--- a/lite/tests/detection/test_average_precision.py
+++ b/lite/tests/detection/test_average_precision.py
@@ -46,6 +46,7 @@ def test__compute_average_precision():
     assert expected.shape == average_precision.shape
     assert np.isclose(average_precision, expected).all()
 
+    # since only one class, ap == map
     assert expected.flatten().shape == mean_average_precision.shape
     assert np.isclose(mean_average_precision, expected.flatten()).all()
 
@@ -69,15 +70,15 @@ def test_ap_metrics_first_class(
 
     groundtruths
         datum uid1
-            box 1 - label (k1, v1) - tp
+            box 1 - label v1 - tp
         datum uid2
-            box 2 - label (k1, v1) - fn misclassification
+            box 2 - label v1 - fn missing prediction
 
     predictions
         datum uid1
-            box 1 - label (k1, v1) - score 0.3 - tp
+            box 1 - label v1 - score 0.3 - tp
         datum uid2
-            none - fn
+            none
     """
 
     for input_, method in [
@@ -188,14 +189,14 @@ def test_ap_metrics_second_class(
 
     groundtruths
         datum uid1
-            box 3 - label (k2, v2) - fn missing prediction
+            box 3 - label v2 - fn missing prediction
         datum uid2
-            none - fn
+           none
     predictions
         datum uid1
             none
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            box 2 - label v2 - score 0.98 - fp
     """
 
     for input_, method in [

--- a/lite/tests/detection/test_average_recall.py
+++ b/lite/tests/detection/test_average_recall.py
@@ -55,6 +55,8 @@ def test__compute_average_recall():
             [0.0],
         ]
     )
+
+    # since only one class, ar == mar
     assert expected.flatten().shape == mean_average_recall.shape
     assert np.isclose(mean_average_recall, expected.flatten()).all()
 
@@ -82,15 +84,15 @@ def test_ar_metrics_first_class(
 
     groundtruths
         datum uid1
-            box 1 - label (k1, v1) - tp
+            box 1 - label v1 - tp
         datum uid2
-            box 2 - label (k1, v1) - fn misclassification
+            box 2 - label v1 - fn missing prediction
 
     predictions
         datum uid1
-            box 1 - label (k1, v1) - score 0.3 - tp
+            box 1 - label v1 - score 0.3 - tp
         datum uid2
-            none - fn
+           none
     """
     for input_, method in [
         (basic_detections_first_class, DataLoader.add_bounding_boxes),
@@ -193,14 +195,14 @@ def test_ar_metrics_second_class(
 
     groundtruths
         datum uid1
-            box 3 - label (k2, v2) - fn missing prediction
+            box 3 - label v2 - fn missing prediction
         datum uid2
-            none - fn
+           none
     predictions
         datum uid1
             none
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            box 2 - label v2 - score 0.98 - fp
     """
     for input_, method in [
         (basic_detections_second_class, DataLoader.add_bounding_boxes),

--- a/lite/tests/detection/test_confusion_matrix.py
+++ b/lite/tests/detection/test_confusion_matrix.py
@@ -420,12 +420,12 @@ def test_confusion_matrix(
     evaluator = loader.finalize()
 
     assert evaluator.ignored_prediction_labels == [
-        ("k1", "not_v2"),
-        ("k1", "hallucination"),
+        "not_v2",
+        "hallucination",
     ]
     assert evaluator.missing_prediction_labels == [
-        ("k1", "missed_detection"),
-        ("k1", "v2"),
+        "missed_detection",
+        "v2",
     ]
     assert evaluator.n_datums == 2
     assert evaluator.n_labels == 6
@@ -509,7 +509,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.05,
                 "iou_threshold": 0.5,
-                "label_key": "k1",
             },
         },
         {
@@ -570,7 +569,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.3,
                 "iou_threshold": 0.5,
-                "label_key": "k1",
             },
         },
         {
@@ -621,7 +619,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.35,
                 "iou_threshold": 0.5,
-                "label_key": "k1",
             },
         },
         {
@@ -672,7 +669,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.45,
                 "iou_threshold": 0.5,
-                "label_key": "k1",
             },
         },
         {
@@ -702,7 +698,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.55,
                 "iou_threshold": 0.5,
-                "label_key": "k1",
             },
         },
         {
@@ -732,7 +727,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.95,
                 "iou_threshold": 0.5,
-                "label_key": "k1",
             },
         },
     ]
@@ -829,7 +823,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.05,
                 "iou_threshold": 0.45,
-                "label_key": "k1",
             },
         },
         {
@@ -894,7 +887,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.3,
                 "iou_threshold": 0.45,
-                "label_key": "k1",
             },
         },
         {
@@ -950,7 +942,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.35,
                 "iou_threshold": 0.45,
-                "label_key": "k1",
             },
         },
         {
@@ -1006,7 +997,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.45,
                 "iou_threshold": 0.45,
-                "label_key": "k1",
             },
         },
         {
@@ -1046,7 +1036,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.55,
                 "iou_threshold": 0.45,
-                "label_key": "k1",
             },
         },
         {
@@ -1086,7 +1075,6 @@ def test_confusion_matrix(
             "parameters": {
                 "score_threshold": 0.95,
                 "iou_threshold": 0.45,
-                "label_key": "k1",
             },
         },
     ]
@@ -1113,7 +1101,7 @@ def test_confusion_matrix_using_torch_metrics_example(
     loader.add_bounding_boxes(torchmetrics_detections)
     evaluator = loader.finalize()
 
-    assert evaluator.ignored_prediction_labels == [("class", "3")]
+    assert evaluator.ignored_prediction_labels == ["3"]
     assert evaluator.missing_prediction_labels == []
     assert evaluator.n_datums == 4
     assert evaluator.n_labels == 6
@@ -1150,7 +1138,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.05,
                 "iou_threshold": 0.5,
-                "label_key": "class",
             },
         },
         {
@@ -1175,7 +1162,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.25,
                 "iou_threshold": 0.5,
-                "label_key": "class",
             },
         },
         {
@@ -1199,7 +1185,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.35,
                 "iou_threshold": 0.5,
-                "label_key": "class",
             },
         },
         {
@@ -1222,7 +1207,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.55,
                 "iou_threshold": 0.5,
-                "label_key": "class",
             },
         },
         {
@@ -1244,7 +1228,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.75,
                 "iou_threshold": 0.5,
-                "label_key": "class",
             },
         },
         {
@@ -1266,7 +1249,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.8,
                 "iou_threshold": 0.5,
-                "label_key": "class",
             },
         },
         {
@@ -1288,7 +1270,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.85,
                 "iou_threshold": 0.5,
-                "label_key": "class",
             },
         },
         {
@@ -1307,7 +1288,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.95,
                 "iou_threshold": 0.5,
-                "label_key": "class",
             },
         },
         {
@@ -1336,7 +1316,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.05,
                 "iou_threshold": 0.9,
-                "label_key": "class",
             },
         },
         {
@@ -1365,7 +1344,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.25,
                 "iou_threshold": 0.9,
-                "label_key": "class",
             },
         },
         {
@@ -1391,7 +1369,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.35,
                 "iou_threshold": 0.9,
-                "label_key": "class",
             },
         },
         {
@@ -1416,7 +1393,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.55,
                 "iou_threshold": 0.9,
-                "label_key": "class",
             },
         },
         {
@@ -1440,7 +1416,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.75,
                 "iou_threshold": 0.9,
-                "label_key": "class",
             },
         },
         {
@@ -1461,7 +1436,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.8,
                 "iou_threshold": 0.9,
-                "label_key": "class",
             },
         },
         {
@@ -1482,7 +1456,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.85,
                 "iou_threshold": 0.9,
-                "label_key": "class",
             },
         },
         {
@@ -1501,7 +1474,6 @@ def test_confusion_matrix_using_torch_metrics_example(
             "parameters": {
                 "score_threshold": 0.95,
                 "iou_threshold": 0.9,
-                "label_key": "class",
             },
         },
     ]
@@ -1587,7 +1559,6 @@ def test_confusion_matrix_fp_hallucination_edge_case(
             "parameters": {
                 "score_threshold": 0.5,
                 "iou_threshold": 0.5,
-                "label_key": "k1",
             },
         },
         {
@@ -1610,7 +1581,6 @@ def test_confusion_matrix_fp_hallucination_edge_case(
             "parameters": {
                 "score_threshold": 0.85,
                 "iou_threshold": 0.5,
-                "label_key": "k1",
             },
         },
     ]
@@ -1649,7 +1619,7 @@ def test_confusion_matrix_ranked_pair_ordering(
 
         assert evaluator.metadata == {
             "ignored_prediction_labels": [
-                ("class", "label4"),
+                "label4",
             ],
             "missing_prediction_labels": [],
             "n_datums": 1,
@@ -1687,7 +1657,6 @@ def test_confusion_matrix_ranked_pair_ordering(
                 "parameters": {
                     "score_threshold": 0.0,
                     "iou_threshold": 0.5,
-                    "label_key": "class",
                 },
             },
         ]

--- a/lite/tests/detection/test_counts.py
+++ b/lite/tests/detection/test_counts.py
@@ -10,15 +10,15 @@ def test_counts_metrics_first_class(
 
     groundtruths
         datum uid1
-            box 1 - label (k1, v1) - tp
+            box 1 - label v1 - tp
         datum uid2
-            box 2 - label (k1, v1) - fn misclassification
+            box 2 - label v1 - fn missing prediction
 
     predictions
         datum uid1
-            box 1 - label (k1, v1) - score 0.3 - tp
+            box 1 - label v1 - score 0.3 - tp
         datum uid2
-            none - fn
+           none
     """
 
     for input_, method in [
@@ -113,14 +113,14 @@ def test_counts_metrics_second_class(
 
     groundtruths
         datum uid1
-            box 3 - label (k2, v2) - fn missing prediction
+            box 3 - label v2 - fn missing prediction
         datum uid2
-            none - fn
+           none
     predictions
         datum uid1
             none
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            box 2 - label v2 - score 0.98 - fp
     """
 
     for input_, method in [

--- a/lite/tests/detection/test_dataloader.py
+++ b/lite/tests/detection/test_dataloader.py
@@ -31,15 +31,9 @@ def test_valor_integration():
     loader.add_bounding_boxes_from_valor_dict([(gt, pd)])
 
     assert len(loader.pairs) == 1
-    assert loader.pairs[0].shape == (71, 7)
+    assert loader.pairs[0].shape == (142, 7)
 
-    assert set(loader._evaluator.label_key_to_index.keys()) == {
-        "iscrowd",
-        "name",
-        "supercategory",
-        "unused_class",
-    }
-    assert len(loader._evaluator.index_to_label) == 17
+    assert len(loader._evaluator.index_to_label) == 24
     assert loader._evaluator.n_datums == 1
 
 
@@ -59,7 +53,7 @@ def test_mixed_annotations(
                     xmax=rect1[1],
                     ymin=rect1[2],
                     ymax=rect1[3],
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                 ),
             ],
             predictions=[
@@ -67,7 +61,7 @@ def test_mixed_annotations(
                     shape=ShapelyPolygon(
                         rect1_rotated_5_degrees_around_origin
                     ),
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.3],
                 ),
             ],
@@ -80,13 +74,13 @@ def test_mixed_annotations(
                     xmax=rect1[1],
                     ymin=rect1[2],
                     ymax=rect1[3],
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                 ),
             ],
             predictions=[
                 Bitmask(
                     mask=np.ones((80, 32), dtype=bool),
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.3],
                 ),
             ],
@@ -96,7 +90,7 @@ def test_mixed_annotations(
             groundtruths=[
                 Bitmask(
                     mask=np.ones((80, 32), dtype=bool),
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.3],
                 ),
             ],
@@ -105,7 +99,7 @@ def test_mixed_annotations(
                     shape=ShapelyPolygon(
                         rect1_rotated_5_degrees_around_origin
                     ),
-                    labels=[("k1", "v1")],
+                    labels=["v1"],
                     scores=[0.3],
                 ),
             ],

--- a/lite/tests/detection/test_evaluator.py
+++ b/lite/tests/detection/test_evaluator.py
@@ -12,7 +12,7 @@ def test_metadata_using_torch_metrics_example(
     loader.add_bounding_boxes(torchmetrics_detections)
     evaluator = loader.finalize()
 
-    assert evaluator.ignored_prediction_labels == [("class", "3")]
+    assert evaluator.ignored_prediction_labels == ["3"]
     assert evaluator.missing_prediction_labels == []
     assert evaluator.n_datums == 4
     assert evaluator.n_labels == 6
@@ -20,9 +20,7 @@ def test_metadata_using_torch_metrics_example(
     assert evaluator.n_predictions == 19
 
     assert evaluator.metadata == {
-        "ignored_prediction_labels": [
-            ("class", "3"),
-        ],
+        "ignored_prediction_labels": ["3"],
         "missing_prediction_labels": [],
         "n_datums": 4,
         "n_labels": 6,
@@ -37,12 +35,12 @@ def test_no_groundtruths(detections_no_groundtruths):
     loader.add_bounding_boxes(detections_no_groundtruths)
     evaluator = loader.finalize()
 
-    assert evaluator.ignored_prediction_labels == [("k1", "v1"), ("k2", "v2")]
+    assert evaluator.ignored_prediction_labels == ["v1"]
     assert evaluator.missing_prediction_labels == []
     assert evaluator.n_datums == 2
-    assert evaluator.n_labels == 2
+    assert evaluator.n_labels == 1
     assert evaluator.n_groundtruths == 0
-    assert evaluator.n_predictions == 3
+    assert evaluator.n_predictions == 2
 
     metrics = evaluator.evaluate(
         iou_thresholds=[0.5],
@@ -59,10 +57,10 @@ def test_no_predictions(detections_no_predictions):
     evaluator = loader.finalize()
 
     assert evaluator.ignored_prediction_labels == []
-    assert evaluator.missing_prediction_labels == [("k1", "v1"), ("k2", "v2")]
+    assert evaluator.missing_prediction_labels == ["v1"]
     assert evaluator.n_datums == 2
-    assert evaluator.n_labels == 2
-    assert evaluator.n_groundtruths == 3
+    assert evaluator.n_labels == 1
+    assert evaluator.n_groundtruths == 2
     assert evaluator.n_predictions == 0
 
     metrics = evaluator.evaluate(
@@ -70,7 +68,7 @@ def test_no_predictions(detections_no_predictions):
         score_thresholds=[0.5],
     )
 
-    assert len(metrics[MetricType.AP]) == 2
+    assert len(metrics[MetricType.AP]) == 1
 
     # test AP
     actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
@@ -80,15 +78,7 @@ def test_no_predictions(detections_no_predictions):
             "value": 0.0,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "k1", "value": "v1"},
-            },
-        },
-        {
-            "type": "AP",
-            "value": 0.0,
-            "parameters": {
-                "iou_threshold": 0.5,
-                "label": {"key": "k2", "value": "v2"},
+                "label": "v1",
             },
         },
     ]
@@ -98,10 +88,10 @@ def test_no_predictions(detections_no_predictions):
         assert m in actual_metrics
 
 
-def test_metrics_to_return(basic_detections: list[Detection]):
+def test_metrics_to_return(basic_detections_first_class: list[Detection]):
 
     loader = DataLoader()
-    loader.add_bounding_boxes(basic_detections)
+    loader.add_bounding_boxes(basic_detections_first_class)
     evaluator = loader.finalize()
 
     metrics_to_return = [

--- a/lite/tests/detection/test_filtering.py
+++ b/lite/tests/detection/test_filtering.py
@@ -6,21 +6,27 @@ from valor_lite.detection import BoundingBox, DataLoader, Detection, MetricType
 
 
 @pytest.fixture
-def one_detection(basic_detections: list[Detection]) -> list[Detection]:
-    return [basic_detections[0]]
+def one_detection(
+    basic_detections_first_class: list[Detection],
+) -> list[Detection]:
+    return [basic_detections_first_class[0]]
 
 
 @pytest.fixture
-def two_detections(basic_detections: list[Detection]) -> list[Detection]:
-    return basic_detections
+def two_detections(
+    basic_detections_first_class: list[Detection],
+) -> list[Detection]:
+    return basic_detections_first_class
 
 
 @pytest.fixture
-def four_detections(basic_detections: list[Detection]) -> list[Detection]:
-    det1 = basic_detections[0]
-    det2 = basic_detections[1]
-    det3 = replace(basic_detections[0])
-    det4 = replace(basic_detections[1])
+def four_detections(
+    basic_detections_first_class: list[Detection],
+) -> list[Detection]:
+    det1 = basic_detections_first_class[0]
+    det2 = basic_detections_first_class[1]
+    det3 = replace(basic_detections_first_class[0])
+    det4 = replace(basic_detections_first_class[1])
 
     det3.uid = "uid3"
     det4.uid = "uid4"
@@ -28,7 +34,7 @@ def four_detections(basic_detections: list[Detection]) -> list[Detection]:
     return [det1, det2, det3, det4]
 
 
-def generate_random_detections(
+def _generate_random_detections(
     n_detections: int, n_boxes: int, labels: str
 ) -> list[Detection]:
     from random import choice, uniform
@@ -42,7 +48,7 @@ def generate_random_detections(
             xmax,
             ymin,
             ymax,
-            [("cl", choice(labels))],
+            [choice(labels)],
             **kw,
         )
 
@@ -88,59 +94,55 @@ def test_filtering_one_detection(one_detection: list[Detection]):
         == np.array(
             [
                 [
-                    [1, 1],
+                    [1],
                 ],
                 [
-                    [1, 0],
+                    [1],
                 ],
             ]
         )
     ).all()
 
     assert (
-        evaluator._label_metadata == np.array([[1, 1, 0], [1, 0, 1]])
+        evaluator._label_metadata
+        == np.array(
+            [
+                [
+                    1,
+                    1,
+                ]
+            ]
+        )
     ).all()
 
     # test datum filtering
     filter_ = evaluator.create_filter(datum_uids=["uid1"])
     assert (filter_.ranked_indices == np.array([0])).all()
-    assert (filter_.detailed_indices == np.array([0, 1])).all()
-    assert (filter_.label_metadata == np.array([[1, 1, 0], [1, 0, 1]])).all()
+    assert (filter_.detailed_indices == np.array([0, 1, 2])).all()
+    assert (filter_.label_metadata == np.array([[1, 1]])).all()
 
     with pytest.raises(KeyError) as e:
         evaluator.create_filter(datum_uids=["uid2"])
     assert "uid2" in str(e)
 
     # test label filtering
-    filter_ = evaluator.create_filter(labels=[("k1", "v1")])
+    filter_ = evaluator.create_filter(labels=["v1"])
     assert (filter_.ranked_indices == np.array([0])).all()
-    assert (filter_.detailed_indices == np.array([0])).all()
-    assert (filter_.label_metadata == np.array([[1, 1, 0], [0, 0, 1]])).all()
+    assert (filter_.detailed_indices == np.array([0, 1])).all()
+    assert (filter_.label_metadata == np.array([[1, 1]])).all()
 
-    filter_ = evaluator.create_filter(labels=[("k2", "v2")])
-    assert (filter_.ranked_indices == np.array([])).all()
-    assert (filter_.detailed_indices == np.array([1])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [1, 0, 1]])).all()
-
-    # test label key filtering
-    filter_ = evaluator.create_filter(label_keys=["k1"])
-    assert (filter_.ranked_indices == np.array([0])).all()
-    assert (filter_.detailed_indices == np.array([0])).all()
-    assert (filter_.label_metadata == np.array([[1, 1, 0], [0, 0, 1]])).all()
-
-    filter_ = evaluator.create_filter(label_keys=["k2"])
-    assert (filter_.ranked_indices == np.array([])).all()
-    assert (filter_.detailed_indices == np.array([1])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [1, 0, 1]])).all()
+    # v2 isn't a label in the data
+    with pytest.raises(KeyError):
+        evaluator.create_filter(labels=["v2"])
 
     # test combo
     filter_ = evaluator.create_filter(
         datum_uids=["uid1"],
-        label_keys=["k1"],
+        labels=["v1"],
     )
     assert (filter_.ranked_indices == np.array([0])).all()
-    assert (filter_.detailed_indices == np.array([0])).all()
-    assert (filter_.label_metadata == np.array([[1, 1, 0], [0, 0, 1]])).all()
+    assert (filter_.detailed_indices == np.array([0, 1])).all()
+    assert (filter_.label_metadata == np.array([[1, 1]])).all()
 
     # test evaluation
     filter_ = evaluator.create_filter(datum_uids=["uid1"])
@@ -156,15 +158,7 @@ def test_filtering_one_detection(one_detection: list[Detection]):
             "value": 1.0,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "k1", "value": "v1"},
-            },
-        },
-        {
-            "type": "AP",
-            "value": 0.0,
-            "parameters": {
-                "iou_threshold": 0.5,
-                "label": {"key": "k2", "value": "v2"},
+                "label": "v1",
             },
         },
     ]
@@ -181,7 +175,6 @@ def test_filtering_two_detections(two_detections: list[Detection]):
     groundtruths
         datum uid1
             box 1 - label (k1, v1) - tp
-            box 3 - label (k2, v2) - fn missing prediction
         datum uid2
             box 2 - label (k1, v1) - fn misclassification
 
@@ -189,7 +182,7 @@ def test_filtering_two_detections(two_detections: list[Detection]):
         datum uid1
             box 1 - label (k1, v1) - score 0.3 - tp
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            none - fn
     """
 
     loader = DataLoader()
@@ -198,12 +191,7 @@ def test_filtering_two_detections(two_detections: list[Detection]):
 
     assert (
         evaluator._ranked_pairs
-        == np.array(
-            [
-                [1.0, -1.0, 0.0, 0.0, -1.0, 1.0, 0.98],
-                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.3],
-            ]
-        )
+        == np.array([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.3]])
     ).all()
 
     assert (
@@ -211,62 +199,54 @@ def test_filtering_two_detections(two_detections: list[Detection]):
         == np.array(
             [
                 [
-                    [1, 1],
-                    [1, 0],
+                    [1],
+                    [1],
                 ],
                 [
-                    [1, 0],
-                    [0, 1],
+                    [1],
+                    [0],
                 ],
             ]
         )
     ).all()
 
-    assert (
-        evaluator._label_metadata == np.array([[2, 1, 0], [1, 1, 1]])
-    ).all()
+    assert (evaluator._label_metadata == np.array([[2, 1]])).all()
 
     # test datum filtering
     filter_ = evaluator.create_filter(datum_uids=["uid1"])
-    assert (filter_.ranked_indices == np.array([1])).all()
-    assert (filter_.detailed_indices == np.array([0, 1])).all()
-    assert (filter_.label_metadata == np.array([[1, 1, 0], [1, 0, 1]])).all()
+    assert (filter_.ranked_indices == np.array([0])).all()
+    assert (filter_.detailed_indices == np.array([0, 1, 2])).all()
+    assert (filter_.label_metadata == np.array([[1, 1]])).all()
 
     filter_ = evaluator.create_filter(datum_uids=["uid2"])
     assert (filter_.ranked_indices == np.array([0])).all()
-    assert (filter_.detailed_indices == np.array([2, 3])).all()
-    assert (filter_.label_metadata == np.array([[1, 0, 0], [0, 1, 1]])).all()
+    assert (filter_.detailed_indices == np.array([3, 4])).all()
+    assert (filter_.label_metadata == np.array([[1, 1]])).all()
 
     # test label filtering
-    filter_ = evaluator.create_filter(labels=[("k1", "v1")])
-    assert (filter_.ranked_indices == np.array([1])).all()
-    assert (filter_.detailed_indices == np.array([0, 2])).all()
-    assert (filter_.label_metadata == np.array([[2, 1, 0], [0, 0, 1]])).all()
-
-    filter_ = evaluator.create_filter(labels=[("k2", "v2")])
-    assert (filter_.ranked_indices == np.array([])).all()
-    assert (filter_.detailed_indices == np.array([1])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [1, 1, 1]])).all()
-
-    # test label key filtering
-    filter_ = evaluator.create_filter(label_keys=["k1"])
-    assert (filter_.ranked_indices == np.array([1])).all()
-    assert (filter_.detailed_indices == np.array([0, 2])).all()
-    assert (filter_.label_metadata == np.array([[2, 1, 0], [0, 0, 1]])).all()
-
-    filter_ = evaluator.create_filter(label_keys=["k2"])
-    assert (filter_.ranked_indices == np.array([])).all()
-    assert (filter_.detailed_indices == np.array([1])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [1, 1, 1]])).all()
+    filter_ = evaluator.create_filter(labels=["v1"])
+    assert (filter_.ranked_indices == np.array([0])).all()
+    assert (filter_.detailed_indices == np.array([0, 1, 3, 4])).all()
+    assert (
+        filter_.label_metadata
+        == np.array(
+            [
+                [
+                    2,
+                    1,
+                ]
+            ]
+        )
+    ).all()
 
     # test combo
     filter_ = evaluator.create_filter(
         datum_uids=["uid1"],
-        label_keys=["k1"],
+        labels=["v1"],
     )
-    assert (filter_.ranked_indices == np.array([1])).all()
-    assert (filter_.detailed_indices == np.array([0])).all()
-    assert (filter_.label_metadata == np.array([[1, 1, 0], [0, 0, 1]])).all()
+    assert (filter_.ranked_indices == np.array([0])).all()
+    assert (filter_.detailed_indices == np.array([0, 1])).all()
+    assert (filter_.label_metadata == np.array([[1, 1]])).all()
 
     # test evaluation
     filter_ = evaluator.create_filter(datum_uids=["uid1"])
@@ -282,15 +262,7 @@ def test_filtering_two_detections(two_detections: list[Detection]):
             "value": 1.0,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "k1", "value": "v1"},
-            },
-        },
-        {
-            "type": "AP",
-            "value": 0.0,
-            "parameters": {
-                "iou_threshold": 0.5,
-                "label": {"key": "k2", "value": "v2"},
+                "label": "v1",
             },
         },
     ]
@@ -307,24 +279,23 @@ def test_filtering_four_detections(four_detections: list[Detection]):
     groundtruths
         datum uid1
             box 1 - label (k1, v1) - tp
-            box 3 - label (k2, v2) - fn missing prediction
         datum uid2
             box 2 - label (k1, v1) - fn misclassification
         datum uid3
             box 1 - label (k1, v1) - tp
-            box 3 - label (k2, v2) - fn missing prediction
         datum uid4
             box 2 - label (k1, v1) - fn misclassification
+
 
     predictions
         datum uid1
             box 1 - label (k1, v1) - score 0.3 - tp
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            none - fn
         datum uid3
             box 1 - label (k1, v1) - score 0.3 - tp
         datum uid4
-            box 2 - label (k2, v2) - score 0.98 - fp
+            none - fn
     """
 
     loader = DataLoader()
@@ -335,8 +306,6 @@ def test_filtering_four_detections(four_detections: list[Detection]):
         evaluator._ranked_pairs
         == np.array(
             [
-                [1.0, -1.0, 0.0, 0.0, -1.0, 1.0, 0.98],
-                [3.0, -1.0, 0.0, 0.0, -1.0, 1.0, 0.98],
                 [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.3],
                 [2.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.3],
             ]
@@ -346,69 +315,39 @@ def test_filtering_four_detections(four_detections: list[Detection]):
     assert (
         evaluator._label_metadata_per_datum
         == np.array(
-            [
-                [
-                    [1, 1],
-                    [1, 0],
-                    [1, 1],
-                    [1, 0],
-                ],
-                [
-                    [1, 0],
-                    [0, 1],
-                    [1, 0],
-                    [0, 1],
-                ],
-            ],
-            dtype=np.int32,
+            [[[1], [1], [1], [1]], [[1], [0], [1], [0]]], dtype=np.int32
         )
     ).all()
 
-    assert (
-        evaluator._label_metadata == np.array([[4, 2, 0], [2, 2, 1]])
-    ).all()
+    assert (evaluator._label_metadata == np.array([[4, 2]])).all()
 
     # test datum filtering
     filter_ = evaluator.create_filter(datum_uids=["uid1"])
-    assert (filter_.ranked_indices == np.array([2])).all()
-    assert (filter_.detailed_indices == np.array([0, 1])).all()
-    assert (filter_.label_metadata == np.array([[1, 1, 0], [1, 0, 1]])).all()
+    assert (filter_.ranked_indices == np.array([0])).all()
+    assert (filter_.detailed_indices == np.array([0, 1, 2])).all()
+    assert (filter_.label_metadata == np.array([[1, 2]])).all()
 
     filter_ = evaluator.create_filter(datum_uids=["uid2"])
     assert (filter_.ranked_indices == np.array([0])).all()
-    assert (filter_.detailed_indices == np.array([2, 3])).all()
-    assert (filter_.label_metadata == np.array([[1, 0, 0], [0, 1, 1]])).all()
+    assert (filter_.detailed_indices == np.array([3, 4])).all()
+    assert (filter_.label_metadata == np.array([[1, 2]])).all()
 
     # test label filtering
-    filter_ = evaluator.create_filter(labels=[("k1", "v1")])
-    assert (filter_.ranked_indices == np.array([2, 3])).all()
-    assert (filter_.detailed_indices == np.array([0, 2, 4, 6])).all()
-    assert (filter_.label_metadata == np.array([[4, 2, 0], [0, 0, 1]])).all()
-
-    filter_ = evaluator.create_filter(labels=[("k2", "v2")])
-    assert (filter_.ranked_indices == np.array([])).all()
-    assert (filter_.detailed_indices == np.array([1, 5])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [2, 2, 1]])).all()
-
-    # test label key filtering
-    filter_ = evaluator.create_filter(label_keys=["k1"])
-    assert (filter_.ranked_indices == np.array([2, 3])).all()
-    assert (filter_.detailed_indices == np.array([0, 2, 4, 6])).all()
-    assert (filter_.label_metadata == np.array([[4, 2, 0], [0, 0, 1]])).all()
-
-    filter_ = evaluator.create_filter(label_keys=["k2"])
-    assert (filter_.ranked_indices == np.array([])).all()
-    assert (filter_.detailed_indices == np.array([1, 5])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [2, 2, 1]])).all()
+    filter_ = evaluator.create_filter(labels=["v1"])
+    assert (filter_.ranked_indices == np.array([0, 1])).all()
+    assert (
+        filter_.detailed_indices == np.array([0, 1, 3, 4, 5, 6, 8, 9])
+    ).all()
+    assert (filter_.label_metadata == np.array([[4, 2]])).all()
 
     # test combo
     filter_ = evaluator.create_filter(
         datum_uids=["uid1"],
-        label_keys=["k1"],
+        labels=["v1"],
     )
-    assert (filter_.ranked_indices == np.array([2])).all()
-    assert (filter_.detailed_indices == np.array([0])).all()
-    assert (filter_.label_metadata == np.array([[1, 1, 0], [0, 0, 1]])).all()
+    assert (filter_.ranked_indices == np.array([0])).all()
+    assert (filter_.detailed_indices == np.array([0, 1])).all()
+    assert (filter_.label_metadata == np.array([[1, 2]])).all()
 
     # test evaluation
     filter_ = evaluator.create_filter(datum_uids=["uid1"])
@@ -425,15 +364,7 @@ def test_filtering_four_detections(four_detections: list[Detection]):
             "value": 1.0,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "k1", "value": "v1"},
-            },
-        },
-        {
-            "type": "AP",
-            "value": 0.0,
-            "parameters": {
-                "iou_threshold": 0.5,
-                "label": {"key": "k2", "value": "v2"},
+                "label": "v1",
             },
         },
     ]
@@ -450,24 +381,23 @@ def test_filtering_all_detections(four_detections: list[Detection]):
     groundtruths
         datum uid1
             box 1 - label (k1, v1) - tp
-            box 3 - label (k2, v2) - fn missing prediction
         datum uid2
             box 2 - label (k1, v1) - fn misclassification
         datum uid3
             box 1 - label (k1, v1) - tp
-            box 3 - label (k2, v2) - fn missing prediction
         datum uid4
             box 2 - label (k1, v1) - fn misclassification
+
 
     predictions
         datum uid1
             box 1 - label (k1, v1) - score 0.3 - tp
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            none - fn
         datum uid3
             box 1 - label (k1, v1) - score 0.3 - tp
         datum uid4
-            box 2 - label (k2, v2) - score 0.98 - fp
+            none - fn
     """
 
     loader = DataLoader()
@@ -478,8 +408,6 @@ def test_filtering_all_detections(four_detections: list[Detection]):
         evaluator._ranked_pairs
         == np.array(
             [
-                [1.0, -1.0, 0.0, 0.0, -1.0, 1.0, 0.98],
-                [3.0, -1.0, 0.0, 0.0, -1.0, 1.0, 0.98],
                 [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.3],
                 [2.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.3],
             ]
@@ -491,55 +419,44 @@ def test_filtering_all_detections(four_detections: list[Detection]):
         == np.array(
             [
                 [
-                    [1, 1],
-                    [1, 0],
-                    [1, 1],
-                    [1, 0],
+                    [1],
+                    [1],
+                    [1],
+                    [1],
                 ],
                 [
-                    [1, 0],
-                    [0, 1],
-                    [1, 0],
-                    [0, 1],
+                    [1],
+                    [0],
+                    [1],
+                    [0],
                 ],
             ],
             dtype=np.int32,
         )
     ).all()
 
-    assert (
-        evaluator._label_metadata == np.array([[4, 2, 0], [2, 2, 1]])
-    ).all()
+    assert (evaluator._label_metadata == np.array([[4, 2]])).all()
 
     # test datum filtering
-
     filter_ = evaluator.create_filter(datum_uids=[])
     assert (filter_.ranked_indices == np.array([])).all()
     assert (filter_.detailed_indices == np.array([])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [0, 0, 1]])).all()
+    assert (filter_.label_metadata == np.array([[0, 2]])).all()
 
     # test label filtering
-
     filter_ = evaluator.create_filter(labels=[])
     assert (filter_.ranked_indices == np.array([])).all()
     assert (filter_.detailed_indices == np.array([])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [0, 0, 1]])).all()
-
-    # test label key filtering
-
-    filter_ = evaluator.create_filter(label_keys=[])
-    assert (filter_.ranked_indices == np.array([[]])).all()
-    assert (filter_.detailed_indices == np.array([])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [0, 0, 1]])).all()
+    assert (filter_.label_metadata == np.array([[0, 2]])).all()
 
     # test combo
     filter_ = evaluator.create_filter(
         datum_uids=[],
-        label_keys=["k1"],
+        labels=["v1"],
     )
     assert (filter_.ranked_indices == np.array([])).all()
     assert (filter_.detailed_indices == np.array([])).all()
-    assert (filter_.label_metadata == np.array([[0, 0, 0], [0, 0, 1]])).all()
+    assert (filter_.label_metadata == np.array([[0, 2]])).all()
 
     # test evaluation
     filter_ = evaluator.create_filter(datum_uids=[])
@@ -559,7 +476,7 @@ def test_filtering_all_detections(four_detections: list[Detection]):
 
 def test_filtering_random_detections():
     loader = DataLoader()
-    loader.add_bounding_boxes(generate_random_detections(13, 4, "abc"))
+    loader.add_bounding_boxes(_generate_random_detections(13, 4, "abc"))
     evaluator = loader.finalize()
     f = evaluator.create_filter(datum_uids=["uid1"])
     evaluator.evaluate(filter_=f)

--- a/lite/tests/detection/test_filtering.py
+++ b/lite/tests/detection/test_filtering.py
@@ -221,7 +221,7 @@ def test_filtering_two_detections(two_detections: list[Detection]):
     filter_ = evaluator.create_filter(datum_uids=["uid2"])
     assert (filter_.ranked_indices == np.array([0])).all()
     assert (filter_.detailed_indices == np.array([3, 4])).all()
-    assert (filter_.label_metadata == np.array([[1, 1]])).all()
+    assert (filter_.label_metadata == np.array([[1, 0]])).all()
 
     # test label filtering
     filter_ = evaluator.create_filter(labels=["v1"])
@@ -325,12 +325,12 @@ def test_filtering_four_detections(four_detections: list[Detection]):
     filter_ = evaluator.create_filter(datum_uids=["uid1"])
     assert (filter_.ranked_indices == np.array([0])).all()
     assert (filter_.detailed_indices == np.array([0, 1, 2])).all()
-    assert (filter_.label_metadata == np.array([[1, 2]])).all()
+    assert (filter_.label_metadata == np.array([[1, 1]])).all()
 
     filter_ = evaluator.create_filter(datum_uids=["uid2"])
     assert (filter_.ranked_indices == np.array([0])).all()
     assert (filter_.detailed_indices == np.array([3, 4])).all()
-    assert (filter_.label_metadata == np.array([[1, 2]])).all()
+    assert (filter_.label_metadata == np.array([[1, 0]])).all()
 
     # test label filtering
     filter_ = evaluator.create_filter(labels=["v1"])
@@ -347,7 +347,7 @@ def test_filtering_four_detections(four_detections: list[Detection]):
     )
     assert (filter_.ranked_indices == np.array([0])).all()
     assert (filter_.detailed_indices == np.array([0, 1])).all()
-    assert (filter_.label_metadata == np.array([[1, 2]])).all()
+    assert (filter_.label_metadata == np.array([[1, 1]])).all()
 
     # test evaluation
     filter_ = evaluator.create_filter(datum_uids=["uid1"])
@@ -441,13 +441,13 @@ def test_filtering_all_detections(four_detections: list[Detection]):
     filter_ = evaluator.create_filter(datum_uids=[])
     assert (filter_.ranked_indices == np.array([])).all()
     assert (filter_.detailed_indices == np.array([])).all()
-    assert (filter_.label_metadata == np.array([[0, 2]])).all()
+    assert (filter_.label_metadata == np.array([[0, 0]])).all()
 
     # test label filtering
     filter_ = evaluator.create_filter(labels=[])
     assert (filter_.ranked_indices == np.array([])).all()
     assert (filter_.detailed_indices == np.array([])).all()
-    assert (filter_.label_metadata == np.array([[0, 2]])).all()
+    assert (filter_.label_metadata == np.array([[0, 0]])).all()
 
     # test combo
     filter_ = evaluator.create_filter(
@@ -456,7 +456,7 @@ def test_filtering_all_detections(four_detections: list[Detection]):
     )
     assert (filter_.ranked_indices == np.array([])).all()
     assert (filter_.detailed_indices == np.array([])).all()
-    assert (filter_.label_metadata == np.array([[0, 2]])).all()
+    assert (filter_.label_metadata == np.array([[0, 0]])).all()
 
     # test evaluation
     filter_ = evaluator.create_filter(datum_uids=[])

--- a/lite/tests/detection/test_pr_curve.py
+++ b/lite/tests/detection/test_pr_curve.py
@@ -47,7 +47,7 @@ def test_pr_curve_using_torch_metrics_example(
     loader.add_bounding_boxes(torchmetrics_detections)
     evaluator = loader.finalize()
 
-    assert evaluator.ignored_prediction_labels == [("class", "3")]
+    assert evaluator.ignored_prediction_labels == ["3"]
     assert evaluator.missing_prediction_labels == []
     assert evaluator.n_datums == 4
     assert evaluator.n_labels == 6
@@ -95,7 +95,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": a,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -103,7 +103,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": d,
             "parameters": {
                 "iou_threshold": 0.75,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -111,7 +111,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": a,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -119,7 +119,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": a,
             "parameters": {
                 "iou_threshold": 0.75,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -127,7 +127,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": b,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
         {
@@ -135,7 +135,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": b,
             "parameters": {
                 "iou_threshold": 0.75,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
         {
@@ -143,7 +143,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": a,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "class", "value": "4"},
+                "label": "4",
             },
         },
         {
@@ -151,7 +151,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": a,
             "parameters": {
                 "iou_threshold": 0.75,
-                "label": {"key": "class", "value": "4"},
+                "label": "4",
             },
         },
         {
@@ -159,7 +159,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": c,
             "parameters": {
                 "iou_threshold": 0.5,
-                "label": {"key": "class", "value": "49"},
+                "label": "49",
             },
         },
         {
@@ -167,7 +167,7 @@ def test_pr_curve_using_torch_metrics_example(
             "value": e,
             "parameters": {
                 "iou_threshold": 0.75,
-                "label": {"key": "class", "value": "49"},
+                "label": "49",
             },
         },
     ]

--- a/lite/tests/detection/test_precision.py
+++ b/lite/tests/detection/test_precision.py
@@ -1,9 +1,9 @@
 from valor_lite.detection import DataLoader, Detection, MetricType
 
 
-def test_precision_metrics(
-    basic_detections: list[Detection],
-    basic_rotated_detections: list[Detection],
+def test_precision_metrics_first_class(
+    basic_detections_first_class: list[Detection],
+    basic_rotated_detections_first_class: list[Detection],
 ):
     """
     Basic object detection test.
@@ -22,8 +22,8 @@ def test_precision_metrics(
             box 2 - label (k2, v2) - score 0.98 - fp
     """
     for input_, method in [
-        (basic_detections, DataLoader.add_bounding_boxes),
-        (basic_rotated_detections, DataLoader.add_polygons),
+        (basic_detections_first_class, DataLoader.add_bounding_boxes),
+        (basic_rotated_detections_first_class, DataLoader.add_polygons),
     ]:
         loader = DataLoader()
         method(loader, input_)
@@ -37,9 +37,93 @@ def test_precision_metrics(
         assert evaluator.ignored_prediction_labels == []
         assert evaluator.missing_prediction_labels == []
         assert evaluator.n_datums == 2
-        assert evaluator.n_labels == 2
-        assert evaluator.n_groundtruths == 3
-        assert evaluator.n_predictions == 2
+        assert evaluator.n_labels == 1
+        assert evaluator.n_groundtruths == 2
+        assert evaluator.n_predictions == 1
+
+        # test Precision
+        actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+        expected_metrics = [
+            {
+                "type": "Precision",
+                "value": 1.0,
+                "parameters": {
+                    "iou_threshold": 0.1,
+                    "score_threshold": 0.0,
+                    "label": "v1",
+                },
+            },
+            {
+                "type": "Precision",
+                "value": 1.0,
+                "parameters": {
+                    "iou_threshold": 0.6,
+                    "score_threshold": 0.0,
+                    "label": "v1",
+                },
+            },
+            {
+                "type": "Precision",
+                "value": 0.0,
+                "parameters": {
+                    "iou_threshold": 0.1,
+                    "score_threshold": 0.5,
+                    "label": "v1",
+                },
+            },
+            {
+                "type": "Precision",
+                "value": 0.0,
+                "parameters": {
+                    "iou_threshold": 0.6,
+                    "score_threshold": 0.5,
+                    "label": "v1",
+                },
+            },
+        ]
+        for m in actual_metrics:
+            assert m in expected_metrics
+        for m in expected_metrics:
+            assert m in actual_metrics
+
+
+def test_precision_metrics_second_class(
+    basic_detections_second_class: list[Detection],
+    basic_rotated_detections_second_class: list[Detection],
+):
+    """
+    Basic object detection test.
+
+    groundtruths
+        datum uid1
+            box 3 - label (k2, v2) - fn missing prediction
+        datum uid2
+            none - fn
+    predictions
+        datum uid1
+            none
+        datum uid2
+            box 2 - label (k2, v2) - score 0.98 - fp
+    """
+    for input_, method in [
+        (basic_detections_second_class, DataLoader.add_bounding_boxes),
+        (basic_rotated_detections_second_class, DataLoader.add_polygons),
+    ]:
+        loader = DataLoader()
+        method(loader, input_)
+        evaluator = loader.finalize()
+
+        metrics = evaluator.evaluate(
+            iou_thresholds=[0.1, 0.6],
+            score_thresholds=[0.0, 0.5],
+        )
+
+        assert evaluator.ignored_prediction_labels == []
+        assert evaluator.missing_prediction_labels == []
+        assert evaluator.n_datums == 2
+        assert evaluator.n_labels == 1
+        assert evaluator.n_groundtruths == 1
+        assert evaluator.n_predictions == 1
 
         # test Precision
         actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
@@ -50,7 +134,7 @@ def test_precision_metrics(
                 "parameters": {
                     "iou_threshold": 0.1,
                     "score_threshold": 0.0,
-                    "label": {"key": "k2", "value": "v2"},
+                    "label": "v2",
                 },
             },
             {
@@ -59,25 +143,7 @@ def test_precision_metrics(
                 "parameters": {
                     "iou_threshold": 0.6,
                     "score_threshold": 0.0,
-                    "label": {"key": "k2", "value": "v2"},
-                },
-            },
-            {
-                "type": "Precision",
-                "value": 1.0,
-                "parameters": {
-                    "iou_threshold": 0.1,
-                    "score_threshold": 0.0,
-                    "label": {"key": "k1", "value": "v1"},
-                },
-            },
-            {
-                "type": "Precision",
-                "value": 1.0,
-                "parameters": {
-                    "iou_threshold": 0.6,
-                    "score_threshold": 0.0,
-                    "label": {"key": "k1", "value": "v1"},
+                    "label": "v2",
                 },
             },
             {
@@ -86,7 +152,7 @@ def test_precision_metrics(
                 "parameters": {
                     "iou_threshold": 0.1,
                     "score_threshold": 0.5,
-                    "label": {"key": "k2", "value": "v2"},
+                    "label": "v2",
                 },
             },
             {
@@ -95,25 +161,7 @@ def test_precision_metrics(
                 "parameters": {
                     "iou_threshold": 0.6,
                     "score_threshold": 0.5,
-                    "label": {"key": "k2", "value": "v2"},
-                },
-            },
-            {
-                "type": "Precision",
-                "value": 0.0,
-                "parameters": {
-                    "iou_threshold": 0.1,
-                    "score_threshold": 0.5,
-                    "label": {"key": "k1", "value": "v1"},
-                },
-            },
-            {
-                "type": "Precision",
-                "value": 0.0,
-                "parameters": {
-                    "iou_threshold": 0.6,
-                    "score_threshold": 0.5,
-                    "label": {"key": "k1", "value": "v1"},
+                    "label": "v2",
                 },
             },
         ]
@@ -147,10 +195,7 @@ def test_precision_false_negatives_single_datum_baseline(
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.0,
-                "label": {
-                    "key": "key",
-                    "value": "value",
-                },
+                "label": "value",
             },
         },
         {
@@ -159,10 +204,7 @@ def test_precision_false_negatives_single_datum_baseline(
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.9,
-                "label": {
-                    "key": "key",
-                    "value": "value",
-                },
+                "label": "value",
             },
         },
     ]
@@ -193,10 +235,7 @@ def test_precision_false_negatives_single_datum(
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.0,
-                "label": {
-                    "key": "key",
-                    "value": "value",
-                },
+                "label": "value",
             },
         }
     ]
@@ -235,10 +274,7 @@ def test_precision_false_negatives_two_datums_one_empty_low_confidence_of_fp(
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.0,
-                "label": {
-                    "key": "key",
-                    "value": "value",
-                },
+                "label": "value",
             },
         }
     ]
@@ -276,10 +312,7 @@ def test_precision_false_negatives_two_datums_one_empty_high_confidence_of_fp(
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.0,
-                "label": {
-                    "key": "key",
-                    "value": "value",
-                },
+                "label": "value",
             },
         }
     ]
@@ -317,10 +350,7 @@ def test_precision_false_negatives_two_datums_one_only_with_different_class_low_
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.0,
-                "label": {
-                    "key": "key",
-                    "value": "value",
-                },
+                "label": "value",
             },
         },
         {
@@ -329,10 +359,7 @@ def test_precision_false_negatives_two_datums_one_only_with_different_class_low_
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.0,
-                "label": {
-                    "key": "key",
-                    "value": "other value",
-                },
+                "label": "other value",
             },
         },
     ]
@@ -370,10 +397,7 @@ def test_precision_false_negatives_two_datums_one_only_with_different_class_high
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.0,
-                "label": {
-                    "key": "key",
-                    "value": "value",
-                },
+                "label": "value",
             },
         },
         {
@@ -382,10 +406,7 @@ def test_precision_false_negatives_two_datums_one_only_with_different_class_high
             "parameters": {
                 "iou_threshold": 0.5,
                 "score_threshold": 0.0,
-                "label": {
-                    "key": "key",
-                    "value": "other value",
-                },
+                "label": "other value",
             },
         },
     ]

--- a/lite/tests/detection/test_precision.py
+++ b/lite/tests/detection/test_precision.py
@@ -43,7 +43,7 @@ def test_precision_metrics_first_class(
         assert evaluator.n_predictions == 1
 
         # test Precision
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.Precision]]
+        actual_metrics = [m for m in metrics[MetricType.Precision]]
         expected_metrics = [
             {
                 "type": "Precision",
@@ -117,6 +117,7 @@ def test_precision_metrics_second_class(
         metrics = evaluator.evaluate(
             iou_thresholds=[0.1, 0.6],
             score_thresholds=[0.0, 0.5],
+            as_dict=True,
         )
 
         assert evaluator.ignored_prediction_labels == []

--- a/lite/tests/detection/test_precision.py
+++ b/lite/tests/detection/test_precision.py
@@ -10,16 +10,16 @@ def test_precision_metrics_first_class(
 
     groundtruths
         datum uid1
-            box 1 - label (k1, v1) - tp
-            box 3 - label (k2, v2) - fn missing prediction
+            box 1 - label v1 - tp
+            box 3 - label v2 - fn missing prediction
         datum uid2
-            box 2 - label (k1, v1) - fn misclassification
+            box 2 - label v1 - fn missing prediction
 
     predictions
         datum uid1
-            box 1 - label (k1, v1) - score 0.3 - tp
+            box 1 - label v1 - score 0.3 - tp
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            box 2 - label v2 - score 0.98 - fp
     """
     for input_, method in [
         (basic_detections_first_class, DataLoader.add_bounding_boxes),
@@ -97,14 +97,14 @@ def test_precision_metrics_second_class(
 
     groundtruths
         datum uid1
-            box 3 - label (k2, v2) - fn missing prediction
+            box 3 - label v2 - fn missing prediction
         datum uid2
-            none - fn
+           none
     predictions
         datum uid1
             none
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            box 2 - label v2 - score 0.98 - fp
     """
     for input_, method in [
         (basic_detections_second_class, DataLoader.add_bounding_boxes),

--- a/lite/tests/detection/test_recall.py
+++ b/lite/tests/detection/test_recall.py
@@ -10,15 +10,15 @@ def test_recall_metrics_first_class(
 
     groundtruths
         datum uid1
-            box 1 - label (k1, v1) - tp
+            box 1 - label v1 - tp
         datum uid2
-            box 2 - label (k1, v1) - fn misclassification
+            box 2 - label v1 - fn missing prediction
 
     predictions
         datum uid1
-            box 1 - label (k1, v1) - score 0.3 - tp
+            box 1 - label v1 - score 0.3 - tp
         datum uid2
-            none - fn
+           none
     """
     for input_, method in [
         (basic_detections_first_class, DataLoader.add_bounding_boxes),
@@ -96,14 +96,14 @@ def test_recall_metrics_second_class(
 
     groundtruths
         datum uid1
-            box 3 - label (k2, v2) - fn missing prediction
+            box 3 - label v2 - fn missing prediction
         datum uid2
-            none - fn
+           none
     predictions
         datum uid1
             none
         datum uid2
-            box 2 - label (k2, v2) - score 0.98 - fp
+            box 2 - label v2 - score 0.98 - fp
     """
     for input_, method in [
         (basic_detections_second_class, DataLoader.add_bounding_boxes),

--- a/lite/tests/detection/test_recall.py
+++ b/lite/tests/detection/test_recall.py
@@ -42,7 +42,7 @@ def test_recall_metrics_first_class(
         assert evaluator.n_predictions == 1
 
         # test Recall
-        actual_metrics = [m.to_dict() for m in metrics[MetricType.Recall]]
+        actual_metrics = [m for m in metrics[MetricType.Recall]]
         expected_metrics = [
             {
                 "type": "Recall",
@@ -116,6 +116,7 @@ def test_recall_metrics_second_class(
         metrics = evaluator.evaluate(
             iou_thresholds=[0.1, 0.6],
             score_thresholds=[0.0, 0.5],
+            as_dict=True,
         )
 
         assert evaluator.ignored_prediction_labels == []

--- a/lite/tests/detection/test_schemas.py
+++ b/lite/tests/detection/test_schemas.py
@@ -6,7 +6,7 @@ from valor_lite.detection import Bitmask, BoundingBox, Detection, Polygon
 
 def test_BoundingBox():
     # groundtruth
-    gt = BoundingBox(xmin=0, xmax=1, ymin=0, ymax=1, labels=[("k", "v")])
+    gt = BoundingBox(xmin=0, xmax=1, ymin=0, ymax=1, labels=["label"])
 
     # prediction
     pd = BoundingBox(
@@ -14,7 +14,7 @@ def test_BoundingBox():
         xmax=11,
         ymin=0,
         ymax=1,
-        labels=[("k", "v")],
+        labels=["label"],
         scores=[0.7],
     )
 
@@ -24,7 +24,7 @@ def test_BoundingBox():
             xmax=1,
             ymin=0,
             ymax=1,
-            labels=[("k", "v")],
+            labels=["label"],
             scores=[0.7, 0.1],
         )
     with pytest.raises(ValueError):
@@ -33,7 +33,7 @@ def test_BoundingBox():
             xmax=1,
             ymin=0,
             ymax=1,
-            labels=[("k", "v1"), ("k", "v2")],
+            labels=["label1", "label2"],
             scores=[0.7],
         )
 
@@ -48,12 +48,12 @@ def test_Bitmask():
     mask[:5, :5] = True
 
     # groundtruth
-    gt = Bitmask(mask=mask, labels=[("k", "v")])
+    gt = Bitmask(mask=mask, labels=["label"])
 
     # prediction
     Bitmask(
         mask=mask,
-        labels=[("k", "v")],
+        labels=["label"],
         scores=[0.7],
     )
 
@@ -61,13 +61,13 @@ def test_Bitmask():
     with pytest.raises(ValueError):
         Bitmask(
             mask=np.zeros((10, 10), dtype=np.bool_),
-            labels=[("k", "v")],
+            labels=["label"],
             scores=[0.7, 0.1],
         )
     with pytest.raises(ValueError):
         Bitmask(
             mask=np.zeros((10, 10), dtype=np.bool_),
-            labels=[("k", "v1"), ("k", "v2")],
+            labels=["label1", "label2"],
             scores=[0.7],
         )
 
@@ -76,7 +76,7 @@ def test_Bitmask():
     assert box
     assert box.extrema == (0, 4, 0, 4)
 
-    empty_box = Bitmask(mask=np.array([]), labels=[("k", "v")])
+    empty_box = Bitmask(mask=np.array([]), labels=["label"])
 
     assert empty_box.to_box() is None
 
@@ -86,12 +86,12 @@ def test_Polygon(rect1_rotated_5_degrees_around_origin):
     shape = ShapelyPolygon(rect1_rotated_5_degrees_around_origin)
 
     # groundtruth
-    gt = Polygon(shape=shape, labels=[("k", "v")])
+    gt = Polygon(shape=shape, labels=["label"])
 
     # prediction
     Polygon(
         shape=shape,
-        labels=[("k", "v")],
+        labels=["label"],
         scores=[0.7],
     )
 
@@ -99,20 +99,20 @@ def test_Polygon(rect1_rotated_5_degrees_around_origin):
     with pytest.raises(ValueError):
         Polygon(
             shape=shape,
-            labels=[("k", "v")],
+            labels=["label"],
             scores=[0.7, 0.1],
         )
     with pytest.raises(ValueError):
         Polygon(
             shape=shape,
-            labels=[("k", "v1"), ("k", "v2")],
+            labels=["label1", "label2"],
             scores=[0.7],
         )
     # test that we throw a type error if the shape isn't a shapely.geometry.Polygon
     with pytest.raises(TypeError):
         Polygon(
             shape=np.zeros((10, 10), dtype=np.bool_),  # type: ignore - purposefully throwing error
-            labels=[("k", "v1"), ("k", "v2")],
+            labels=["label1", "label2"],
             scores=[0.7],
         )
 
@@ -126,7 +126,7 @@ def test_Polygon(rect1_rotated_5_degrees_around_origin):
         45.07713248852931,
     )
 
-    empty_box = Polygon(shape=ShapelyPolygon([]), labels=[("k", "v")])
+    empty_box = Polygon(shape=ShapelyPolygon([]), labels=["label"])
 
     assert empty_box.to_box() is None
 
@@ -134,7 +134,7 @@ def test_Polygon(rect1_rotated_5_degrees_around_origin):
 def test_Detection():
 
     # groundtruth
-    gt = BoundingBox(xmin=0, xmax=1, ymin=0, ymax=1, labels=[("k", "v")])
+    gt = BoundingBox(xmin=0, xmax=1, ymin=0, ymax=1, labels=["label"])
 
     # prediction
     pd = BoundingBox(
@@ -142,7 +142,7 @@ def test_Detection():
         xmax=11,
         ymin=0,
         ymax=1,
-        labels=[("k", "v")],
+        labels=["label"],
         scores=[0.7],
     )
 

--- a/lite/tests/detection/test_stability.py
+++ b/lite/tests/detection/test_stability.py
@@ -3,7 +3,7 @@ from random import choice, uniform
 from valor_lite.detection import BoundingBox, DataLoader, Detection
 
 
-def generate_random_detections(
+def _generate_random_detections(
     n_detections: int, n_boxes: int, labels: str
 ) -> list[Detection]:
     def bbox(is_prediction):
@@ -17,7 +17,7 @@ def generate_random_detections(
             xmax,
             ymin,
             ymax,
-            [("class", choice(labels)), ("category", choice(labels))],
+            [choice(labels), choice(labels)],
             **kw,
         )
 
@@ -43,7 +43,7 @@ def test_fuzz_detections():
         n_detections = choice(quantities)
         n_boxes = choice(quantities)
 
-        detections = generate_random_detections(n_detections, n_boxes, labels)
+        detections = _generate_random_detections(n_detections, n_boxes, labels)
 
         loader = DataLoader()
         loader.add_bounding_boxes(detections)
@@ -66,18 +66,16 @@ def test_fuzz_detections_with_filtering():
         n_detections = choice(quantities)
         n_boxes = choice(quantities)
 
-        detections = generate_random_detections(n_detections, n_boxes, labels)
+        detections = _generate_random_detections(n_detections, n_boxes, labels)
 
         loader = DataLoader()
         loader.add_bounding_boxes(detections)
         evaluator = loader.finalize()
 
-        label_key = "class"
         datum_subset = [f"uid{i}" for i in range(len(detections) // 2)]
 
         filter_ = evaluator.create_filter(
             datum_uids=datum_subset,
-            label_keys=[label_key],
         )
 
         evaluator.evaluate(

--- a/lite/valor_lite/detection/annotation.py
+++ b/lite/valor_lite/detection/annotation.py
@@ -11,7 +11,7 @@ class BoundingBox:
     xmax: float
     ymin: float
     ymax: float
-    labels: list[tuple[str, str]]
+    labels: list[str]
     scores: list[float] = field(default_factory=list)
 
     def __post_init__(self):
@@ -28,7 +28,7 @@ class BoundingBox:
 @dataclass
 class Polygon:
     shape: ShapelyPolygon
-    labels: list[tuple[str, str]]
+    labels: list[str]
     scores: list[float] = field(default_factory=list)
 
     def __post_init__(self):
@@ -59,7 +59,7 @@ class Polygon:
 @dataclass
 class Bitmask:
     mask: NDArray[np.bool_]
-    labels: list[tuple[str, str]]
+    labels: list[str]
     scores: list[float] = field(default_factory=list)
 
     def __post_init__(self):

--- a/lite/valor_lite/detection/computation.py
+++ b/lite/valor_lite/detection/computation.py
@@ -276,9 +276,9 @@ def compute_metrics(
 
     Returns
     -------
-    tuple[NDArray, NDArray, NDArray float]
+    tuple[NDArray, NDArray, NDArray, float]
         Average Precision results.
-    tuple[NDArray, NDArray, NDArray float]
+    tuple[NDArray, NDArray, NDArray, float]
         Average Recall results.
     np.ndarray
         Precision, Recall, TP, FP, FN, F1 Score, Accuracy.

--- a/lite/valor_lite/detection/computation.py
+++ b/lite/valor_lite/detection/computation.py
@@ -31,6 +31,11 @@ def compute_bbox_iou(data: NDArray[np.floating]) -> NDArray[np.floating]:
     NDArray[np.floating]
         Computed IoU's.
     """
+    iou = np.zeros(data.shape[0])
+
+    # we may not have data if we don't have any predictions for a given datum
+    if data.size == 0:
+        return iou
 
     xmin1, xmax1, ymin1, ymax1 = (
         data[:, 0],
@@ -59,7 +64,6 @@ def compute_bbox_iou(data: NDArray[np.floating]) -> NDArray[np.floating]:
 
     union_area = area1 + area2 - intersection_area
 
-    iou = np.zeros(data.shape[0])
     valid_union_mask = union_area >= 1e-9
     iou[valid_union_mask] = (
         intersection_area[valid_union_mask] / union_area[valid_union_mask]
@@ -235,13 +239,13 @@ def compute_metrics(
         NDArray[np.floating],
         NDArray[np.floating],
         NDArray[np.floating],
-        NDArray[np.floating],
+        float,
     ],
     tuple[
         NDArray[np.floating],
         NDArray[np.floating],
         NDArray[np.floating],
-        NDArray[np.floating],
+        float,
     ],
     NDArray[np.floating],
     NDArray[np.floating],
@@ -272,9 +276,9 @@ def compute_metrics(
 
     Returns
     -------
-    tuple[NDArray, NDArray, NDArray NDArray]
+    tuple[NDArray, NDArray, NDArray float]
         Average Precision results.
-    tuple[NDArray, NDArray, NDArray NDArray]
+    tuple[NDArray, NDArray, NDArray float]
         Average Recall results.
     np.ndarray
         Precision, Recall, TP, FP, FN, F1 Score, Accuracy.
@@ -453,15 +457,8 @@ def compute_metrics(
     average_recall /= n_ious
 
     # calculate mAP and mAR
-    label_key_mapping = label_metadata[unique_pd_labels, 2]
-    label_keys = np.unique(label_metadata[:, 2])
-    mAP = np.ones((n_ious, label_keys.shape[0])) * -1.0
-    mAR = np.ones((n_scores, label_keys.shape[0])) * -1.0
-    for key in np.unique(label_key_mapping):
-        labels = unique_pd_labels[label_key_mapping == key]
-        key_idx = int(key)
-        mAP[:, key_idx] = average_precision[:, labels].mean(axis=1)
-        mAR[:, key_idx] = average_recall[:, labels].mean(axis=1)
+    mAP = average_precision[:, unique_pd_labels].mean(axis=1)
+    mAR = average_recall[:, unique_pd_labels].mean(axis=1)
 
     # calculate AP and mAP averaged over iou thresholds
     APAveragedOverIoUs = average_precision.mean(axis=0)
@@ -537,7 +534,6 @@ def compute_confusion_matrix(
     score_thresholds: NDArray[np.floating],
     n_examples: int,
 ) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.int32]]:
-
     """
     Compute detailed counts.
 
@@ -732,9 +728,9 @@ def compute_confusion_matrix(
             )
 
             # store the counts
-            confusion_matrix[
-                iou_idx, score_idx, tp_labels, tp_labels, 0
-            ] = tp_counts
+            confusion_matrix[iou_idx, score_idx, tp_labels, tp_labels, 0] = (
+                tp_counts
+            )
             confusion_matrix[
                 iou_idx,
                 score_idx,

--- a/lite/valor_lite/detection/computation.py
+++ b/lite/valor_lite/detection/computation.py
@@ -728,9 +728,9 @@ def compute_confusion_matrix(
             )
 
             # store the counts
-            confusion_matrix[iou_idx, score_idx, tp_labels, tp_labels, 0] = (
-                tp_counts
-            )
+            confusion_matrix[
+                iou_idx, score_idx, tp_labels, tp_labels, 0
+            ] = tp_counts
             confusion_matrix[
                 iou_idx,
                 score_idx,

--- a/lite/valor_lite/detection/manager.py
+++ b/lite/valor_lite/detection/manager.py
@@ -295,13 +295,12 @@ class Evaluator:
         label_metadata_per_datum[:, ~mask_label_metadata] = 0
 
         label_metadata = np.zeros_like(self._label_metadata, dtype=np.int32)
-        label_metadata[:, :2] = np.transpose(
+        label_metadata = np.transpose(
             np.sum(
                 label_metadata_per_datum,
                 axis=1,
             )
         )
-        label_metadata[:, 1] = self._label_metadata[:, 1]
 
         return Filter(
             ranked_indices=np.where(mask_ranked)[0],

--- a/lite/valor_lite/detection/manager.py
+++ b/lite/valor_lite/detection/manager.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 
+# TODO ctrl + F for "key"
 import numpy as np
 from numpy.typing import NDArray
 from shapely.geometry import Polygon as ShapelyPolygon
@@ -103,26 +104,25 @@ def _get_annotation_representation_from_valor_dict(
 
 
 def _get_annotation_data(
-    keyed_groundtruths: dict,
-    keyed_predictions: dict,
+    keyed_groundtruths: list,
+    keyed_predictions: list,
     annotation_type: type[BoundingBox] | type[Polygon] | type[Bitmask] | None,
-    key=int,
 ) -> np.ndarray:
     """Create an array of annotation pairs for use when calculating IOU. Needed because we unpack bounding box representations, but not bitmask or polygon representations."""
     if annotation_type == BoundingBox:
         return np.array(
             [
                 np.array([*gextrema, *pextrema])
-                for _, _, _, pextrema in keyed_predictions[key]
-                for _, _, gextrema in keyed_groundtruths[key]
+                for _, _, _, pextrema in keyed_predictions
+                for _, _, gextrema in keyed_groundtruths
             ]
         )
     else:
         return np.array(
             [
                 np.array([groundtruth_obj, prediction_obj])
-                for _, _, _, prediction_obj in keyed_predictions[key]
-                for _, _, groundtruth_obj in keyed_groundtruths[key]
+                for _, _, _, prediction_obj in keyed_predictions
+                for _, _, groundtruth_obj in keyed_groundtruths
             ]
         )
 
@@ -185,13 +185,8 @@ class Evaluator:
         self.prediction_examples: dict[int, NDArray[np.float16]] = dict()
 
         # label reference
-        self.label_to_index: dict[tuple[str, str], int] = dict()
-        self.index_to_label: dict[int, tuple[str, str]] = dict()
-
-        # label key reference
-        self.index_to_label_key: dict[int, str] = dict()
-        self.label_key_to_index: dict[str, int] = dict()
-        self.label_index_to_label_key_index: dict[int, int] = dict()
+        self.label_to_index: dict[str, int] = dict()
+        self.index_to_label: dict[int, str] = dict()
 
         # computation caches
         self._detailed_pairs: NDArray[np.floating] = np.array([])
@@ -200,7 +195,7 @@ class Evaluator:
         self._label_metadata_per_datum: NDArray[np.int32] = np.array([])
 
     @property
-    def ignored_prediction_labels(self) -> list[tuple[str, str]]:
+    def ignored_prediction_labels(self) -> list[str]:
         """
         Prediction labels that are not present in the ground truth set.
         """
@@ -211,7 +206,7 @@ class Evaluator:
         ]
 
     @property
-    def missing_prediction_labels(self) -> list[tuple[str, str]]:
+    def missing_prediction_labels(self) -> list[str]:
         """
         Ground truth labels that are not present in the prediction set.
         """
@@ -238,8 +233,7 @@ class Evaluator:
     def create_filter(
         self,
         datum_uids: list[str] | NDArray[np.int32] | None = None,
-        labels: list[tuple[str, str]] | NDArray[np.int32] | None = None,
-        label_keys: list[str] | NDArray[np.int32] | None = None,
+        labels: list[str] | NDArray[np.int32] | None = None,
     ) -> Filter:
         """
         Creates a filter that can be passed to an evaluation.
@@ -248,10 +242,8 @@ class Evaluator:
         ----------
         datum_uids : list[str] | NDArray[np.int32], optional
             An optional list of string uids or a numpy array of uid indices.
-        labels : list[tuple[str, str]] | NDArray[np.int32], optional
+        labels : list[str] | NDArray[np.int32], optional
             An optional list of labels or a numpy array of label indices.
-        label_keys : list[str] | NDArray[np.int32], optional
-            An optional list of label keys or a numpy array of label key indices.
 
         Returns
         -------
@@ -295,24 +287,6 @@ class Evaluator:
                 ~np.isin(self._detailed_pairs[:, 4].astype(int), labels)
             ] = False
             mask_labels[~np.isin(np.arange(n_labels), labels)] = False
-
-        if label_keys is not None:
-            if isinstance(label_keys, list):
-                label_keys = np.array(
-                    [self.label_key_to_index[key] for key in label_keys]
-                )
-            label_indices = (
-                np.where(np.isclose(self._label_metadata[:, 2], label_keys))[0]
-                if label_keys.size > 0
-                else np.array([])
-            )
-            mask_ranked[
-                ~np.isin(self._ranked_pairs[:, 4].astype(int), label_indices)
-            ] = False
-            mask_detailed[
-                ~np.isin(self._detailed_pairs[:, 4].astype(int), label_indices)
-            ] = False
-            mask_labels[~np.isin(np.arange(n_labels), label_indices)] = False
 
         mask_label_metadata = (
             mask_datums[:, np.newaxis] & mask_labels[np.newaxis, :]
@@ -410,12 +384,10 @@ class Evaluator:
 
         metrics[MetricType.mAP] = [
             mAP(
-                value=mean_average_precision[iou_idx][label_key_idx],
+                value=mean_average_precision[iou_idx],
                 iou_threshold=iou_thresholds[iou_idx],
-                label_key=self.index_to_label_key[label_key_idx],
             )
             for iou_idx in range(mean_average_precision.shape[0])
-            for label_key_idx in range(mean_average_precision.shape[1])
         ]
 
         metrics[MetricType.APAveragedOverIOUs] = [
@@ -430,12 +402,8 @@ class Evaluator:
 
         metrics[MetricType.mAPAveragedOverIOUs] = [
             mAPAveragedOverIOUs(
-                value=mean_average_precision_average_over_ious[label_key_idx],
+                value=mean_average_precision_average_over_ious,
                 iou_thresholds=iou_thresholds,
-                label_key=self.index_to_label_key[label_key_idx],
-            )
-            for label_key_idx in range(
-                mean_average_precision_average_over_ious.shape[0]
             )
         ]
 
@@ -453,13 +421,11 @@ class Evaluator:
 
         metrics[MetricType.mAR] = [
             mAR(
-                value=mean_average_recall[score_idx][label_key_idx],
+                value=mean_average_recall[score_idx],
                 iou_thresholds=iou_thresholds,
                 score_threshold=score_thresholds[score_idx],
-                label_key=self.index_to_label_key[label_key_idx],
             )
             for score_idx in range(mean_average_recall.shape[0])
-            for label_key_idx in range(mean_average_recall.shape[1])
         ]
 
         metrics[MetricType.ARAveragedOverScores] = [
@@ -475,13 +441,9 @@ class Evaluator:
 
         metrics[MetricType.mARAveragedOverScores] = [
             mARAveragedOverScores(
-                value=mean_average_recall_averaged_over_scores[label_key_idx],
+                value=mean_average_recall_averaged_over_scores,
                 score_thresholds=score_thresholds,
                 iou_thresholds=iou_thresholds,
-                label_key=self.index_to_label_key[label_key_idx],
-            )
-            for label_key_idx in range(
-                mean_average_recall_averaged_over_scores.shape[0]
             )
         ]
 
@@ -545,14 +507,14 @@ class Evaluator:
                     )
 
         if MetricType.ConfusionMatrix in metrics_to_return:
-            metrics[
-                MetricType.ConfusionMatrix
-            ] = self._compute_confusion_matrix(
-                data=detailed_pairs,
-                label_metadata=label_metadata,
-                iou_thresholds=iou_thresholds,
-                score_thresholds=score_thresholds,
-                number_of_examples=number_of_examples,
+            metrics[MetricType.ConfusionMatrix] = (
+                self._compute_confusion_matrix(
+                    data=detailed_pairs,
+                    label_metadata=label_metadata,
+                    iou_thresholds=iou_thresholds,
+                    score_thresholds=score_thresholds,
+                    number_of_examples=number_of_examples,
+                )
             )
 
         for metric in set(metrics.keys()):
@@ -564,7 +526,6 @@ class Evaluator:
     def _unpack_confusion_matrix(
         self,
         confusion_matrix: NDArray[np.floating],
-        label_key_idx: int,
         number_of_labels: int,
         number_of_examples: int,
     ) -> dict[
@@ -673,22 +634,13 @@ class Evaluator:
                     ],
                 }
                 for pd_label_idx in range(number_of_labels)
-                if (
-                    self.label_index_to_label_key_index[pd_label_idx]
-                    == label_key_idx
-                )
             }
             for gt_label_idx in range(number_of_labels)
-            if (
-                self.label_index_to_label_key_index[gt_label_idx]
-                == label_key_idx
-            )
         }
 
     def _unpack_hallucinations(
         self,
         hallucinations: NDArray[np.floating],
-        label_key_idx: int,
         number_of_labels: int,
         number_of_examples: int,
     ) -> dict[
@@ -755,16 +707,11 @@ class Evaluator:
                 ],
             }
             for pd_label_idx in range(number_of_labels)
-            if (
-                self.label_index_to_label_key_index[pd_label_idx]
-                == label_key_idx
-            )
         }
 
     def _unpack_missing_predictions(
         self,
         missing_predictions: NDArray[np.int32],
-        label_key_idx: int,
         number_of_labels: int,
         number_of_examples: int,
     ) -> dict[
@@ -820,10 +767,6 @@ class Evaluator:
                 ],
             }
             for gt_label_idx in range(number_of_labels)
-            if (
-                self.label_index_to_label_key_index[gt_label_idx]
-                == label_key_idx
-            )
         }
 
     def _compute_confusion_matrix(
@@ -874,19 +817,16 @@ class Evaluator:
             ConfusionMatrix(
                 iou_threshold=iou_thresholds[iou_idx],
                 score_threshold=score_thresholds[score_idx],
-                label_key=label_key,
                 number_of_examples=number_of_examples,
                 confusion_matrix=self._unpack_confusion_matrix(
                     confusion_matrix=confusion_matrix[
                         iou_idx, score_idx, :, :, :
                     ],
-                    label_key_idx=label_key_idx,
                     number_of_labels=n_labels,
                     number_of_examples=number_of_examples,
                 ),
                 hallucinations=self._unpack_hallucinations(
                     hallucinations=hallucinations[iou_idx, score_idx, :, :],
-                    label_key_idx=label_key_idx,
                     number_of_labels=n_labels,
                     number_of_examples=number_of_examples,
                 ),
@@ -894,12 +834,10 @@ class Evaluator:
                     missing_predictions=missing_predictions[
                         iou_idx, score_idx, :, :
                     ],
-                    label_key_idx=label_key_idx,
                     number_of_labels=n_labels,
                     number_of_examples=number_of_examples,
                 ),
             )
-            for label_key_idx, label_key in self.index_to_label_key.items()
             for iou_idx in range(n_ious)
             for score_idx in range(n_scores)
         ]
@@ -936,50 +874,35 @@ class DataLoader:
             self._evaluator.index_to_uid[index] = uid
         return self._evaluator.uid_to_index[uid]
 
-    def _add_label(self, label: tuple[str, str]) -> tuple[int, int]:
+    def _add_label(self, label: str) -> int:
         """
         Helper function for adding a label to the cache.
 
         Parameters
         ----------
-        label : tuple[str, str]
-            The label as a tuple in format (key, value).
+        label : str
+            The label associated with the annotation.
 
         Returns
         -------
         int
             Label index.
-        int
-            Label key index.
         """
 
         label_id = len(self._evaluator.index_to_label)
-        label_key_id = len(self._evaluator.index_to_label_key)
         if label not in self._evaluator.label_to_index:
             self._evaluator.label_to_index[label] = label_id
             self._evaluator.index_to_label[label_id] = label
 
-            # update label key index
-            if label[0] not in self._evaluator.label_key_to_index:
-                self._evaluator.label_key_to_index[label[0]] = label_key_id
-                self._evaluator.index_to_label_key[label_key_id] = label[0]
-                label_key_id += 1
-
-            self._evaluator.label_index_to_label_key_index[
-                label_id
-            ] = self._evaluator.label_key_to_index[label[0]]
             label_id += 1
 
-        return (
-            self._evaluator.label_to_index[label],
-            self._evaluator.label_key_to_index[label[0]],
-        )
+        return self._evaluator.label_to_index[label]
 
     def _compute_ious_and_cache_pairs(
         self,
         uid_index: int,
-        keyed_groundtruths: dict,
-        keyed_predictions: dict,
+        keyed_groundtruths: list,
+        keyed_predictions: list,
         annotation_type: type[BoundingBox] | type[Polygon] | type[Bitmask],
     ) -> None:
         """
@@ -989,122 +912,116 @@ class DataLoader:
         ----------
         uid_index: int
             The index of the detection.
-        keyed_groundtruths: dict
-            A dictionary of groundtruths.
-        keyed_predictions: dict
-            A dictionary of predictions.
+        # TODO change "keyed" in names
+        keyed_groundtruths: list
+            A list of groundtruths.
+        keyed_predictions: list
+            A list of predictions.
         annotation_type: type[BoundingBox] | type[Polygon] | type[Bitmask]
             The type of annotation to compute IOUs for.
         """
-        gt_keys = set(keyed_groundtruths.keys())
-        pd_keys = set(keyed_predictions.keys())
-        joint_keys = gt_keys.intersection(pd_keys)
-        gt_unique_keys = gt_keys - pd_keys
-        pd_unique_keys = pd_keys - gt_keys
 
         pairs = list()
-        for key in joint_keys:
-            n_predictions = len(keyed_predictions[key])
-            n_groundtruths = len(keyed_groundtruths[key])
-            data = _get_annotation_data(
-                keyed_groundtruths=keyed_groundtruths,
-                keyed_predictions=keyed_predictions,
-                key=key,
-                annotation_type=annotation_type,
-            )
-            ious = compute_iou(data=data, annotation_type=annotation_type)
-            mask_nonzero_iou = (ious > 1e-9).reshape(
-                (n_predictions, n_groundtruths)
-            )
-            mask_ious_halluc = ~(mask_nonzero_iou.any(axis=1))
-            mask_ious_misprd = ~(mask_nonzero_iou.any(axis=0))
+        n_predictions = len(keyed_predictions)
+        n_groundtruths = len(keyed_groundtruths)
+        data = _get_annotation_data(
+            keyed_groundtruths=keyed_groundtruths,
+            keyed_predictions=keyed_predictions,
+            annotation_type=annotation_type,
+        )
 
-            pairs.extend(
-                [
-                    np.array(
-                        [
-                            float(uid_index),
-                            float(gidx),
-                            float(pidx),
-                            ious[pidx * len(keyed_groundtruths[key]) + gidx],
-                            float(glabel),
-                            float(plabel),
-                            float(score),
-                        ]
-                    )
-                    for pidx, plabel, score, _ in keyed_predictions[key]
-                    for gidx, glabel, _ in keyed_groundtruths[key]
-                    if ious[pidx * len(keyed_groundtruths[key]) + gidx] > 1e-9
-                ]
-            )
-            pairs.extend(
-                [
-                    np.array(
-                        [
-                            float(uid_index),
-                            -1.0,
-                            float(pidx),
-                            0.0,
-                            -1.0,
-                            float(plabel),
-                            float(score),
-                        ]
-                    )
-                    for pidx, plabel, score, _ in keyed_predictions[key]
-                    if mask_ious_halluc[pidx]
-                ]
-            )
-            pairs.extend(
-                [
-                    np.array(
-                        [
-                            float(uid_index),
-                            float(gidx),
-                            -1.0,
-                            0.0,
-                            float(glabel),
-                            -1.0,
-                            -1.0,
-                        ]
-                    )
-                    for gidx, glabel, _ in keyed_groundtruths[key]
-                    if mask_ious_misprd[gidx]
-                ]
-            )
-        for key in gt_unique_keys:
-            pairs.extend(
-                [
-                    np.array(
-                        [
-                            float(uid_index),
-                            float(gidx),
-                            -1.0,
-                            0.0,
-                            float(glabel),
-                            -1.0,
-                            -1.0,
-                        ]
-                    )
-                    for gidx, glabel, _ in keyed_groundtruths[key]
-                ]
-            )
-        for key in pd_unique_keys:
-            pairs.extend(
-                [
-                    np.array(
-                        [
-                            float(uid_index),
-                            -1.0,
-                            float(pidx),
-                            0.0,
-                            -1.0,
-                            float(plabel),
-                            float(score),
-                        ]
-                    )
-                    for pidx, plabel, score, _ in keyed_predictions[key]
-                ]
-            )
+        ious = compute_iou(data=data, annotation_type=annotation_type)
+        mask_nonzero_iou = (ious > 1e-9).reshape(
+            (n_predictions, n_groundtruths)
+        )
+        mask_ious_halluc = ~(mask_nonzero_iou.any(axis=1))
+        mask_ious_misprd = ~(mask_nonzero_iou.any(axis=0))
+
+        pairs.extend(
+            [
+                np.array(
+                    [
+                        float(uid_index),
+                        float(gidx),
+                        float(pidx),
+                        ious[pidx * len(keyed_groundtruths) + gidx],
+                        float(glabel),
+                        float(plabel),
+                        float(score),
+                    ]
+                )
+                for pidx, plabel, score, _ in keyed_predictions
+                for gidx, glabel, _ in keyed_groundtruths
+                if ious[pidx * len(keyed_groundtruths) + gidx] > 1e-9
+            ]
+        )
+        pairs.extend(
+            [
+                np.array(
+                    [
+                        float(uid_index),
+                        -1.0,
+                        float(pidx),
+                        0.0,
+                        -1.0,
+                        float(plabel),
+                        float(score),
+                    ]
+                )
+                for pidx, plabel, score, _ in keyed_predictions
+                if mask_ious_halluc[pidx]
+            ]
+        )
+        pairs.extend(
+            [
+                np.array(
+                    [
+                        float(uid_index),
+                        float(gidx),
+                        -1.0,
+                        0.0,
+                        float(glabel),
+                        -1.0,
+                        -1.0,
+                    ]
+                )
+                for gidx, glabel, _ in keyed_groundtruths
+                if mask_ious_misprd[gidx]
+            ]
+        )
+
+        pairs.extend(
+            [
+                np.array(
+                    [
+                        float(uid_index),
+                        float(gidx),
+                        -1.0,
+                        0.0,
+                        float(glabel),
+                        -1.0,
+                        -1.0,
+                    ]
+                )
+                for gidx, glabel, _ in keyed_groundtruths
+            ]
+        )
+        pairs.extend(
+            [
+                np.array(
+                    [
+                        float(uid_index),
+                        -1.0,
+                        float(pidx),
+                        0.0,
+                        -1.0,
+                        float(plabel),
+                        float(score),
+                    ]
+                )
+                for pidx, plabel, score, _ in keyed_predictions
+            ]
+        )
 
         self.pairs.append(np.array(pairs))
 
@@ -1146,8 +1063,8 @@ class DataLoader:
             )
 
             # cache labels and annotations
-            keyed_groundtruths = defaultdict(list)
-            keyed_predictions = defaultdict(list)
+            keyed_groundtruths = list()
+            keyed_predictions = list()
 
             representation_property = _get_annotation_representation(
                 annotation_type=annotation_type
@@ -1160,9 +1077,9 @@ class DataLoader:
                     )
 
                 if isinstance(gann, BoundingBox):
-                    self._evaluator.groundtruth_examples[uid_index][
-                        gidx
-                    ] = getattr(gann, representation_property)
+                    self._evaluator.groundtruth_examples[uid_index][gidx] = (
+                        getattr(gann, representation_property)
+                    )
                 else:
                     converted_box = gann.to_box()
                     self._evaluator.groundtruth_examples[uid_index][gidx] = (
@@ -1171,10 +1088,10 @@ class DataLoader:
                         else None
                     )
                 for glabel in gann.labels:
-                    label_idx, label_key_idx = self._add_label(glabel)
+                    label_idx = self._add_label(glabel)
                     self.groundtruth_count[label_idx][uid_index] += 1
                     representation = getattr(gann, representation_property)
-                    keyed_groundtruths[label_key_idx].append(
+                    keyed_groundtruths.append(
                         (
                             gidx,
                             label_idx,
@@ -1189,9 +1106,9 @@ class DataLoader:
                     )
 
                 if isinstance(pann, BoundingBox):
-                    self._evaluator.prediction_examples[uid_index][
-                        pidx
-                    ] = getattr(pann, representation_property)
+                    self._evaluator.prediction_examples[uid_index][pidx] = (
+                        getattr(pann, representation_property)
+                    )
                 else:
                     converted_box = pann.to_box()
                     self._evaluator.prediction_examples[uid_index][pidx] = (
@@ -1200,12 +1117,12 @@ class DataLoader:
                         else None
                     )
                 for plabel, pscore in zip(pann.labels, pann.scores):
-                    label_idx, label_key_idx = self._add_label(plabel)
+                    label_idx = self._add_label(plabel)
                     self.prediction_count[label_idx][uid_index] += 1
                     representation = representation = getattr(
                         pann, representation_property
                     )
-                    keyed_predictions[label_key_idx].append(
+                    keyed_predictions.append(
                         (
                             pidx,
                             label_idx,
@@ -1322,8 +1239,8 @@ class DataLoader:
             )
 
             # cache labels and annotations
-            keyed_groundtruths = defaultdict(list)
-            keyed_predictions = defaultdict(list)
+            keyed_groundtruths = list()
+            keyed_predictions = list()
 
             annotation_key = _get_valor_dict_annotation_key(
                 annotation_type=annotation_type
@@ -1343,20 +1260,22 @@ class DataLoader:
                         f"Input JSON doesn't contain {annotation_type} data, or contains data for multiple annotation types."
                     )
                 if annotation_type == BoundingBox:
-                    self._evaluator.groundtruth_examples[uid_index][
-                        gidx
-                    ] = np.array(
-                        _get_annotation_representation_from_valor_dict(
-                            gann[annotation_key],
-                            annotation_type=annotation_type,
-                        ),
+                    self._evaluator.groundtruth_examples[uid_index][gidx] = (
+                        np.array(
+                            _get_annotation_representation_from_valor_dict(
+                                gann[annotation_key],
+                                annotation_type=annotation_type,
+                            ),
+                        )
                     )
 
                 for valor_label in gann["labels"]:
-                    glabel = (valor_label["key"], valor_label["value"])
-                    label_idx, label_key_idx = self._add_label(glabel)
+                    glabel = valor_label[
+                        "value"
+                    ]  # TODO keys is basically being ignored here. have to deal with benchmarks later
+                    label_idx = self._add_label(glabel)
                     self.groundtruth_count[label_idx][uid_index] += 1
-                    keyed_groundtruths[label_key_idx].append(
+                    keyed_groundtruths.append(
                         (
                             gidx,
                             label_idx,
@@ -1375,20 +1294,20 @@ class DataLoader:
                     )
 
                 if annotation_type == BoundingBox:
-                    self._evaluator.prediction_examples[uid_index][
-                        pidx
-                    ] = np.array(
-                        _get_annotation_representation_from_valor_dict(
-                            pann[annotation_key],
-                            annotation_type=annotation_type,
+                    self._evaluator.prediction_examples[uid_index][pidx] = (
+                        np.array(
+                            _get_annotation_representation_from_valor_dict(
+                                pann[annotation_key],
+                                annotation_type=annotation_type,
+                            )
                         )
                     )
                 for valor_label in pann["labels"]:
-                    plabel = (valor_label["key"], valor_label["value"])
+                    plabel = valor_label["value"]
                     pscore = valor_label["score"]
-                    label_idx, label_key_idx = self._add_label(plabel)
+                    label_idx = self._add_label(plabel)
                     self.prediction_count[label_idx][uid_index] += 1
-                    keyed_predictions[label_key_idx].append(
+                    keyed_predictions.append(
                         (
                             pidx,
                             label_idx,
@@ -1482,11 +1401,6 @@ class DataLoader:
                                 1, :, label_idx
                             ]
                         )
-                    ),
-                    float(
-                        self._evaluator.label_index_to_label_key_index[
-                            label_idx
-                        ]
                     ),
                 ]
                 for label_idx in range(n_labels)

--- a/lite/valor_lite/detection/metric.py
+++ b/lite/valor_lite/detection/metric.py
@@ -46,7 +46,7 @@ class Counts:
     tp: int
     fp: int
     fn: int
-    label: tuple[str, str]
+    label: str
     iou_threshold: float
     score_threshold: float
 
@@ -62,10 +62,7 @@ class Counts:
             parameters={
                 "iou_threshold": self.iou_threshold,
                 "score_threshold": self.score_threshold,
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
+                "label": self.label,
             },
         )
 
@@ -76,7 +73,7 @@ class Counts:
 @dataclass
 class ClassMetric:
     value: float
-    label: tuple[str, str]
+    label: str
     iou_threshold: float
     score_threshold: float
 
@@ -88,10 +85,7 @@ class ClassMetric:
             parameters={
                 "iou_threshold": self.iou_threshold,
                 "score_threshold": self.score_threshold,
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
+                "label": self.label,
             },
         )
 
@@ -119,7 +113,7 @@ class F1(ClassMetric):
 class AP:
     value: float
     iou_threshold: float
-    label: tuple[str, str]
+    label: str
 
     @property
     def metric(self) -> Metric:
@@ -128,10 +122,7 @@ class AP:
             value=self.value,
             parameters={
                 "iou_threshold": self.iou_threshold,
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
+                "label": self.label,
             },
         )
 
@@ -143,7 +134,6 @@ class AP:
 class mAP:
     value: float
     iou_threshold: float
-    label_key: str
 
     @property
     def metric(self) -> Metric:
@@ -152,7 +142,6 @@ class mAP:
             value=self.value,
             parameters={
                 "iou_threshold": self.iou_threshold,
-                "label_key": self.label_key,
             },
         )
 
@@ -164,7 +153,7 @@ class mAP:
 class APAveragedOverIOUs:
     value: float
     iou_thresholds: list[float]
-    label: tuple[str, str]
+    label: str
 
     @property
     def metric(self) -> Metric:
@@ -173,10 +162,7 @@ class APAveragedOverIOUs:
             value=self.value,
             parameters={
                 "iou_thresholds": self.iou_thresholds,
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
+                "label": self.label,
             },
         )
 
@@ -188,7 +174,6 @@ class APAveragedOverIOUs:
 class mAPAveragedOverIOUs:
     value: float
     iou_thresholds: list[float]
-    label_key: str
 
     @property
     def metric(self) -> Metric:
@@ -197,7 +182,6 @@ class mAPAveragedOverIOUs:
             value=self.value,
             parameters={
                 "iou_thresholds": self.iou_thresholds,
-                "label_key": self.label_key,
             },
         )
 
@@ -210,7 +194,7 @@ class AR:
     value: float
     score_threshold: float
     iou_thresholds: list[float]
-    label: tuple[str, str]
+    label: str
 
     @property
     def metric(self) -> Metric:
@@ -220,10 +204,7 @@ class AR:
             parameters={
                 "score_threshold": self.score_threshold,
                 "iou_thresholds": self.iou_thresholds,
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
+                "label": self.label,
             },
         )
 
@@ -236,7 +217,6 @@ class mAR:
     value: float
     score_threshold: float
     iou_thresholds: list[float]
-    label_key: str
 
     @property
     def metric(self) -> Metric:
@@ -246,7 +226,6 @@ class mAR:
             parameters={
                 "score_threshold": self.score_threshold,
                 "iou_thresholds": self.iou_thresholds,
-                "label_key": self.label_key,
             },
         )
 
@@ -259,7 +238,7 @@ class ARAveragedOverScores:
     value: float
     score_thresholds: list[float]
     iou_thresholds: list[float]
-    label: tuple[str, str]
+    label: str
 
     @property
     def metric(self) -> Metric:
@@ -269,10 +248,7 @@ class ARAveragedOverScores:
             parameters={
                 "score_thresholds": self.score_thresholds,
                 "iou_thresholds": self.iou_thresholds,
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
+                "label": self.label,
             },
         )
 
@@ -285,7 +261,6 @@ class mARAveragedOverScores:
     value: float
     score_thresholds: list[float]
     iou_thresholds: list[float]
-    label_key: str
 
     @property
     def metric(self) -> Metric:
@@ -295,7 +270,6 @@ class mARAveragedOverScores:
             parameters={
                 "score_thresholds": self.score_thresholds,
                 "iou_thresholds": self.iou_thresholds,
-                "label_key": self.label_key,
             },
         )
 
@@ -311,7 +285,7 @@ class PrecisionRecallCurve:
 
     precision: list[float]
     iou_threshold: float
-    label: tuple[str, str]
+    label: str
 
     @property
     def metric(self) -> Metric:
@@ -320,7 +294,7 @@ class PrecisionRecallCurve:
             value=self.precision,
             parameters={
                 "iou_threshold": self.iou_threshold,
-                "label": {"key": self.label[0], "value": self.label[1]},
+                "label": self.label,
             },
         )
 
@@ -385,7 +359,6 @@ class ConfusionMatrix:
     ]
     score_threshold: float
     iou_threshold: float
-    label_key: str
     number_of_examples: int
 
     @property
@@ -400,7 +373,6 @@ class ConfusionMatrix:
             parameters={
                 "score_threshold": self.score_threshold,
                 "iou_threshold": self.iou_threshold,
-                "label_key": self.label_key,
             },
         )
 


### PR DESCRIPTION
## Improvements
- Removed label keys from all functions and tests
- Added a DeprecationWarning to the `...from_valor_dict` inner function
- Turn off some API benchmarks since a) they are failing our GH workflows and b) they aren't offering us useful information given the upcoming API changes