### PR TITLE
Remove label keys from `lite` classification

### DIFF
--- a/lite/tests/classification/conftest.py
+++ b/lite/tests/classification/conftest.py
@@ -322,7 +322,7 @@ def classifications_multiclass() -> list[Classification]:
 
 
 @pytest.fixture
-def classifications_multiclass_true_negatives_check_animals() -> (
+def classifications_multiclass_true_negatives_check() -> (
     list[Classification]
 ):
     return [
@@ -330,20 +330,6 @@ def classifications_multiclass_true_negatives_check_animals() -> (
             uid="uid1",
             groundtruths=["ant"],
             predictions=["ant", "bee", "cat"],
-            scores=[0.15, 0.48, 0.37],
-        ),
-    ]
-
-
-@pytest.fixture
-def classifications_multiclass_true_negatives_check_ingredients() -> (
-    list[Classification]
-):
-    return [
-        Classification(
-            uid="uid2",
-            groundtruths=["egg"],
-            predictions=["egg", "milk", "flour"],
             scores=[0.15, 0.48, 0.37],
         ),
     ]

--- a/lite/tests/classification/conftest.py
+++ b/lite/tests/classification/conftest.py
@@ -7,34 +7,34 @@ def basic_classifications() -> list[Classification]:
     return [
         Classification(
             uid="uid0",
-            groundtruths=[("class", "0")],
+            groundtruths=["0"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
-                ("class", "3"),
+                "0",
+                "1",
+                "2",
+                "3",
             ],
             scores=[1.0, 0.0, 0.0, 0.0],
         ),
         Classification(
             uid="uid1",
-            groundtruths=[("class", "0")],
+            groundtruths=["0"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
-                ("class", "3"),
+                "0",
+                "1",
+                "2",
+                "3",
             ],
             scores=[0.0, 0.0, 1.0, 0.0],
         ),
         Classification(
             uid="uid2",
-            groundtruths=[("class", "3")],
+            groundtruths=["3"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
-                ("class", "3"),
+                "0",
+                "1",
+                "2",
+                "3",
             ],
             scores=[0.0, 0.0, 0.0, 0.3],
         ),
@@ -57,61 +57,61 @@ def classifications_from_api_unit_tests() -> list[Classification]:
     return [
         Classification(
             uid="uid0",
-            groundtruths=[("class", "0")],
+            groundtruths=["0"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
+                "0",
+                "1",
+                "2",
             ],
             scores=[1.0, 0.0, 0.0],
         ),
         Classification(
             uid="uid1",
-            groundtruths=[("class", "0")],
+            groundtruths=["0"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
+                "0",
+                "1",
+                "2",
             ],
             scores=[0.0, 1.0, 0.0],
         ),
         Classification(
             uid="uid2",
-            groundtruths=[("class", "0")],
+            groundtruths=["0"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
+                "0",
+                "1",
+                "2",
             ],
             scores=[0.0, 0.0, 1.0],
         ),
         Classification(
             uid="uid3",
-            groundtruths=[("class", "1")],
+            groundtruths=["1"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
+                "0",
+                "1",
+                "2",
             ],
             scores=[0.0, 1.0, 0.0],
         ),
         Classification(
             uid="uid4",
-            groundtruths=[("class", "2")],
+            groundtruths=["2"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
+                "0",
+                "1",
+                "2",
             ],
             scores=[0.0, 1.0, 0.0],
         ),
         Classification(
             uid="uid5",
-            groundtruths=[("class", "2")],
+            groundtruths=["2"],
             predictions=[
-                ("class", "0"),
-                ("class", "1"),
-                ("class", "2"),
+                "0",
+                "1",
+                "2",
             ],
             scores=[0.0, 1.0, 0.0],
         ),
@@ -119,7 +119,7 @@ def classifications_from_api_unit_tests() -> list[Classification]:
 
 
 @pytest.fixture
-def classifications_two_categories() -> list[Classification]:
+def classifications_animal_example() -> list[Classification]:
     animal_gts = ["bird", "dog", "bird", "bird", "cat", "dog"]
     animal_pds = [
         {"bird": 0.6, "dog": 0.2, "cat": 0.2},
@@ -131,6 +131,19 @@ def classifications_two_categories() -> list[Classification]:
         # Note: In the case of a tied score, the ordering of predictions is used.
     ]
 
+    return [
+        Classification(
+            uid=f"uid{idx}",
+            groundtruths=[gt],
+            predictions=list(pd.keys()),
+            scores=list(pd.values()),
+        )
+        for idx, (gt, pd) in enumerate(zip(animal_gts, animal_pds))
+    ]
+
+
+@pytest.fixture
+def classifications_color_example() -> list[Classification]:
     color_gts = ["white", "white", "red", "blue", "black", "red"]
     color_pds = [
         {"white": 0.65, "red": 0.1, "blue": 0.2, "black": 0.05},
@@ -141,29 +154,14 @@ def classifications_two_categories() -> list[Classification]:
         {"red": 0.9, "white": 0.06, "blue": 0.01, "black": 0.03},
     ]
 
-    joint_gts = zip(animal_gts, color_gts)
-    joint_pds = [
-        {
-            "animal": animal,
-            "color": color,
-        }
-        for animal, color in zip(animal_pds, color_pds)
-    ]
-
     return [
         Classification(
             uid=f"uid{idx}",
-            groundtruths=[("animal", gt[0]), ("color", gt[1])],
-            predictions=[
-                (key, value)
-                for key, values in pd.items()
-                for value in values.keys()
-            ],
-            scores=[
-                score for values in pd.values() for score in values.values()
-            ],
+            groundtruths=[gt],
+            predictions=list(pd.keys()),
+            scores=list(pd.values()),
         )
-        for idx, (gt, pd) in enumerate(zip(joint_gts, joint_pds))
+        for idx, (gt, pd) in enumerate(zip(color_gts, color_pds))
     ]
 
 
@@ -173,35 +171,24 @@ def classifications_image_example() -> list[Classification]:
         Classification(
             uid="uid5",
             groundtruths=[
-                ("k4", "v4"),
-                ("k5", "v5"),
+                "v4",
             ],
             predictions=[
-                ("k4", "v1"),
-                ("k4", "v8"),
-                ("k5", "v1"),
+                "v1",
+                "v8",
             ],
-            scores=[0.47, 0.53, 1.0],
+            scores=[0.47, 0.53],
         ),
         Classification(
             uid="uid6",
             groundtruths=[
-                ("k4", "v4"),
-            ],
-            predictions=[("k4", "v4"), ("k4", "v5")],
-            scores=[0.71, 0.29],
-        ),
-        Classification(
-            uid="uid8",
-            groundtruths=[
-                ("k3", "v3"),
+                "v4",
             ],
             predictions=[
-                ("k3", "v1"),
+                "v4",
+                "v5",
             ],
-            scores=[
-                1.0,
-            ],
+            scores=[0.71, 0.29],
         ),
     ]
 
@@ -224,10 +211,8 @@ def classifications_tabular_example() -> list[Classification]:
     return [
         Classification(
             uid=f"uid{i}",
-            groundtruths=[("class", str(gt_label))],
-            predictions=[
-                ("class", str(pd_label)) for pd_label, _ in enumerate(pds)
-            ],
+            groundtruths=[str(gt_label)],
+            predictions=[str(pd_label) for pd_label, _ in enumerate(pds)],
             scores=pds,
         )
         for i, (gt_label, pds) in enumerate(
@@ -242,7 +227,7 @@ def classifications_no_groundtruths() -> list[Classification]:
         Classification(
             uid="uid1",
             groundtruths=[],
-            predictions=[("k1", "v1"), ("k1", "v2")],
+            predictions=["v1", "v2"],
             scores=[0.8, 0.2],
         )
     ]
@@ -253,7 +238,7 @@ def classifications_no_predictions() -> list[Classification]:
     return [
         Classification(
             uid="uid1",
-            groundtruths=[("k1", "v1"), ("k2", "v2")],
+            groundtruths=["v1", "v2"],
             predictions=[],
             scores=[],
         )
@@ -265,11 +250,11 @@ def classifications_multiclass() -> list[Classification]:
     return [
         Classification(
             uid="uid0",
-            groundtruths=[("class_label", "cat")],
+            groundtruths=["cat"],
             predictions=[
-                ("class_label", "cat"),
-                ("class_label", "dog"),
-                ("class_label", "bee"),
+                "cat",
+                "dog",
+                "bee",
             ],
             scores=[
                 0.44598543489942505,
@@ -279,11 +264,11 @@ def classifications_multiclass() -> list[Classification]:
         ),
         Classification(
             uid="uid1",
-            groundtruths=[("class_label", "bee")],
+            groundtruths=["bee"],
             predictions=[
-                ("class_label", "cat"),
-                ("class_label", "dog"),
-                ("class_label", "bee"),
+                "cat",
+                "dog",
+                "bee",
             ],
             scores=[
                 0.4076893257212283,
@@ -293,11 +278,11 @@ def classifications_multiclass() -> list[Classification]:
         ),
         Classification(
             uid="uid2",
-            groundtruths=[("class_label", "cat")],
+            groundtruths=["cat"],
             predictions=[
-                ("class_label", "cat"),
-                ("class_label", "dog"),
-                ("class_label", "bee"),
+                "cat",
+                "dog",
+                "bee",
             ],
             scores=[
                 0.25060075263871917,
@@ -307,11 +292,11 @@ def classifications_multiclass() -> list[Classification]:
         ),
         Classification(
             uid="uid3",
-            groundtruths=[("class_label", "bee")],
+            groundtruths=["bee"],
             predictions=[
-                ("class_label", "cat"),
-                ("class_label", "dog"),
-                ("class_label", "bee"),
+                "cat",
+                "dog",
+                "bee",
             ],
             scores=[
                 0.2003514145616792,
@@ -321,11 +306,11 @@ def classifications_multiclass() -> list[Classification]:
         ),
         Classification(
             uid="uid4",
-            groundtruths=[("class_label", "dog")],
+            groundtruths=["dog"],
             predictions=[
-                ("class_label", "cat"),
-                ("class_label", "dog"),
-                ("class_label", "bee"),
+                "cat",
+                "dog",
+                "bee",
             ],
             scores=[
                 0.33443897813714385,
@@ -337,18 +322,28 @@ def classifications_multiclass() -> list[Classification]:
 
 
 @pytest.fixture
-def classifications_multiclass_true_negatives_check() -> list[Classification]:
+def classifications_multiclass_true_negatives_check_animals() -> (
+    list[Classification]
+):
     return [
         Classification(
             uid="uid1",
-            groundtruths=[("k1", "ant")],
-            predictions=[("k1", "ant"), ("k1", "bee"), ("k1", "cat")],
+            groundtruths=["ant"],
+            predictions=["ant", "bee", "cat"],
             scores=[0.15, 0.48, 0.37],
         ),
+    ]
+
+
+@pytest.fixture
+def classifications_multiclass_true_negatives_check_ingredients() -> (
+    list[Classification]
+):
+    return [
         Classification(
             uid="uid2",
-            groundtruths=[("k2", "egg")],
-            predictions=[("k2", "egg"), ("k2", "milk"), ("k2", "flour")],
+            groundtruths=["egg"],
+            predictions=["egg", "milk", "flour"],
             scores=[0.15, 0.48, 0.37],
         ),
     ]
@@ -359,20 +354,8 @@ def classifications_multiclass_zero_count() -> list[Classification]:
     return [
         Classification(
             uid="uid1",
-            groundtruths=[("k", "ant")],
-            predictions=[("k", "ant"), ("k", "bee"), ("k", "cat")],
+            groundtruths=["ant"],
+            predictions=["ant", "bee", "cat"],
             scores=[0.15, 0.48, 0.37],
-        )
-    ]
-
-
-@pytest.fixture
-def classifications_with_label_key_mismatch() -> list[Classification]:
-    return [
-        Classification(
-            uid="uid0",
-            groundtruths=[("k1", "V1")],
-            predictions=[("k2", "v1")],
-            scores=[1.0],
         )
     ]

--- a/lite/tests/classification/test_accuracy.py
+++ b/lite/tests/classification/test_accuracy.py
@@ -77,16 +77,12 @@ def test_accuracy_basic(basic_classifications: list[Classification]):
         "n_groundtruths": 3,
         "n_predictions": 12,
         "n_labels": 4,
-        "ignored_prediction_labels": [
-            ("class", "1"),
-            ("class", "2"),
-        ],
+        "ignored_prediction_labels": ["1", "2"],
         "missing_prediction_labels": [],
     }
 
     metrics = evaluator.evaluate(score_thresholds=[0.25, 0.75], as_dict=True)
 
-    # test Accuracy
     actual_metrics = [m for m in metrics[MetricType.Accuracy]]
     expected_metrics = [
         {
@@ -95,7 +91,7 @@ def test_accuracy_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -104,7 +100,7 @@ def test_accuracy_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "3"},
+                "label": "3",
             },
         },
     ]
@@ -114,17 +110,16 @@ def test_accuracy_basic(basic_classifications: list[Classification]):
         assert m in actual_metrics
 
 
-def test_accuracy_with_example(
-    classifications_two_categories: list[Classification],
+def test_accuracy_with_animal_example(
+    classifications_animal_example: list[Classification],
 ):
 
     loader = DataLoader()
-    loader.add_data(classifications_two_categories)
+    loader.add_data(classifications_animal_example)
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(score_thresholds=[0.5], as_dict=True)
 
-    # test Accuracy
     actual_metrics = [m for m in metrics[MetricType.Accuracy]]
     expected_metrics = [
         {
@@ -133,7 +128,7 @@ def test_accuracy_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "bird"},
+                "label": "bird",
             },
         },
         {
@@ -142,7 +137,7 @@ def test_accuracy_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "dog"},
+                "label": "dog",
             },
         },
         {
@@ -151,43 +146,7 @@ def test_accuracy_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "cat"},
-            },
-        },
-        {
-            "type": "Accuracy",
-            "value": [2 / 3],
-            "parameters": {
-                "score_thresholds": [0.5],
-                "hardmax": True,
-                "label": {"key": "color", "value": "white"},
-            },
-        },
-        {
-            "type": "Accuracy",
-            "value": [2 / 3],
-            "parameters": {
-                "score_thresholds": [0.5],
-                "hardmax": True,
-                "label": {"key": "color", "value": "red"},
-            },
-        },
-        {
-            "type": "Accuracy",
-            "value": [2 / 3],
-            "parameters": {
-                "score_thresholds": [0.5],
-                "hardmax": True,
-                "label": {"key": "color", "value": "blue"},
-            },
-        },
-        {
-            "type": "Accuracy",
-            "value": [5 / 6],
-            "parameters": {
-                "score_thresholds": [0.5],
-                "hardmax": True,
-                "label": {"key": "color", "value": "black"},
+                "label": "cat",
             },
         },
     ]
@@ -197,7 +156,62 @@ def test_accuracy_with_example(
         assert m in actual_metrics
 
 
-def test_accuracy_with_image_example(
+def test_accuracy_color_example(
+    classifications_color_example: list[Classification],
+):
+
+    loader = DataLoader()
+    loader.add_data(classifications_color_example)
+    evaluator = loader.finalize()
+
+    metrics = evaluator.evaluate(score_thresholds=[0.5], as_dict=True)
+
+    actual_metrics = [m for m in metrics[MetricType.Accuracy]]
+    expected_metrics = [
+        {
+            "type": "Accuracy",
+            "value": [2 / 3],
+            "parameters": {
+                "score_thresholds": [0.5],
+                "hardmax": True,
+                "label": "white",
+            },
+        },
+        {
+            "type": "Accuracy",
+            "value": [2 / 3],
+            "parameters": {
+                "score_thresholds": [0.5],
+                "hardmax": True,
+                "label": "red",
+            },
+        },
+        {
+            "type": "Accuracy",
+            "value": [2 / 3],
+            "parameters": {
+                "score_thresholds": [0.5],
+                "hardmax": True,
+                "label": "blue",
+            },
+        },
+        {
+            "type": "Accuracy",
+            "value": [5 / 6],
+            "parameters": {
+                "score_thresholds": [0.5],
+                "hardmax": True,
+                "label": "black",
+            },
+        },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_accuracy_with_image_example(  # TODO add comment about the deleted data here
     classifications_image_example: list[Classification],
 ):
     loader = DataLoader()
@@ -205,53 +219,25 @@ def test_accuracy_with_image_example(
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
-        "n_datums": 3,
-        "n_groundtruths": 4,
-        "n_predictions": 6,
-        "n_labels": 8,
-        "ignored_prediction_labels": [
-            ("k4", "v1"),
-            ("k4", "v8"),
-            ("k5", "v1"),
-            ("k4", "v5"),
-            ("k3", "v1"),
-        ],
-        "missing_prediction_labels": [
-            ("k5", "v5"),
-            ("k3", "v3"),
-        ],
+        "n_datums": 2,
+        "n_groundtruths": 2,
+        "n_predictions": 4,
+        "n_labels": 4,
+        "ignored_prediction_labels": ["v1", "v8", "v5"],
+        "missing_prediction_labels": [],
     }
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test Accuracy
     actual_metrics = [m for m in metrics[MetricType.Accuracy]]
     expected_metrics = [
         {
             "type": "Accuracy",
-            "value": [0.3333333333333333],
+            "value": [0.5],  # TODO add comment about the bug here
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "k4", "value": "v4"},
-            },
-        },
-        {
-            "type": "Accuracy",
-            "value": [0.0],
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k5", "value": "v5"},
-            },
-        },
-        {
-            "type": "Accuracy",
-            "value": [0.0],
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k3", "value": "v3"},
+                "label": "v4",
             },
         },
     ]
@@ -279,7 +265,6 @@ def test_accuracy_with_tabular_example(
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test Accuracy
     actual_metrics = [m for m in metrics[MetricType.Accuracy]]
     expected_metrics = [
         {
@@ -288,7 +273,7 @@ def test_accuracy_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -297,7 +282,7 @@ def test_accuracy_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -306,7 +291,7 @@ def test_accuracy_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
     ]

--- a/lite/tests/classification/test_accuracy.py
+++ b/lite/tests/classification/test_accuracy.py
@@ -211,7 +211,7 @@ def test_accuracy_color_example(
         assert m in actual_metrics
 
 
-def test_accuracy_with_image_example(  # TODO add comment about the deleted data here
+def test_accuracy_with_image_example(
     classifications_image_example: list[Classification],
 ):
     loader = DataLoader()
@@ -233,7 +233,7 @@ def test_accuracy_with_image_example(  # TODO add comment about the deleted data
     expected_metrics = [
         {
             "type": "Accuracy",
-            "value": [0.5],  # TODO add comment about the bug here
+            "value": [0.5],
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,

--- a/lite/tests/classification/test_confusion_matrix.py
+++ b/lite/tests/classification/test_confusion_matrix.py
@@ -110,10 +110,7 @@ def test_confusion_matrix_basic(basic_classifications: list[Classification]):
         "n_groundtruths": 3,
         "n_predictions": 12,
         "n_labels": 4,
-        "ignored_prediction_labels": [
-            ("class", "1"),
-            ("class", "2"),
-        ],
+        "ignored_prediction_labels": ["1", "2"],
         "missing_prediction_labels": [],
     }
 
@@ -124,7 +121,6 @@ def test_confusion_matrix_basic(basic_classifications: list[Classification]):
         as_dict=True,
     )
 
-    # test ConfusionMatrix
     actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
@@ -152,7 +148,7 @@ def test_confusion_matrix_basic(basic_classifications: list[Classification]):
                 },
                 "missing_predictions": {},
             },
-            "parameters": {"score_threshold": 0.25, "label_key": "class"},
+            "parameters": {"score_threshold": 0.25},
         },
         {
             "type": "ConfusionMatrix",
@@ -173,7 +169,7 @@ def test_confusion_matrix_basic(basic_classifications: list[Classification]):
                     "3": {"count": 1, "examples": [{"datum": "uid2"}]}
                 },
             },
-            "parameters": {"score_threshold": 0.75, "label_key": "class"},
+            "parameters": {"score_threshold": 0.75},
         },
     ]
     for m in actual_metrics:
@@ -200,7 +196,6 @@ def test_confusion_matrix_unit(
         as_dict=True,
     )
 
-    # test ConfusionMatrix
     actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
@@ -217,7 +212,7 @@ def test_confusion_matrix_unit(
                 },
                 "missing_predictions": {},
             },
-            "parameters": {"score_threshold": 0.5, "label_key": "class"},
+            "parameters": {"score_threshold": 0.5},
         },
     ]
     for m in actual_metrics:
@@ -230,12 +225,12 @@ def test_confusion_matrix_unit(
         assert m in actual_metrics
 
 
-def test_confusion_matrix_with_example(
-    classifications_two_categories: list[Classification],
+def test_confusion_matrix_with_animal_example(
+    classifications_animal_example: list[Classification],
 ):
 
     loader = DataLoader()
-    loader.add_data(classifications_two_categories)
+    loader.add_data(classifications_animal_example)
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(
@@ -245,7 +240,6 @@ def test_confusion_matrix_with_example(
         as_dict=True,
     )
 
-    # test ConfusionMatrix
     actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
@@ -289,8 +283,36 @@ def test_confusion_matrix_with_example(
                     "dog": {"count": 1, "examples": [{"datum": "uid5"}]}
                 },
             },
-            "parameters": {"score_threshold": 0.5, "label_key": "animal"},
+            "parameters": {"score_threshold": 0.5},
         },
+    ]
+    for m in actual_metrics:
+        _filter_elements_with_zero_count(
+            cm=m["value"]["confusion_matrix"],
+            mp=m["value"]["missing_predictions"],
+        )
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_confusion_matrix_with_color_example(
+    classifications_color_example: list[Classification],
+):
+
+    loader = DataLoader()
+    loader.add_data(classifications_color_example)
+    evaluator = loader.finalize()
+
+    metrics = evaluator.evaluate(
+        metrics_to_return=[MetricType.ConfusionMatrix],
+        score_thresholds=[0.5],
+        number_of_examples=6,
+        as_dict=True,
+    )
+
+    actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
+    expected_metrics = [
         {
             "type": "ConfusionMatrix",
             "value": {
@@ -334,7 +356,7 @@ def test_confusion_matrix_with_example(
                     "red": {"count": 1, "examples": [{"datum": "uid2"}]}
                 },
             },
-            "parameters": {"score_threshold": 0.5, "label_key": "color"},
+            "parameters": {"score_threshold": 0.5},
         },
     ]
     for m in actual_metrics:
@@ -370,7 +392,6 @@ def test_confusion_matrix_multiclass(
         as_dict=True,
     )
 
-    # test ConfusionMatrix
     actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
@@ -416,7 +437,6 @@ def test_confusion_matrix_multiclass(
             },
             "parameters": {
                 "score_threshold": 0.05,
-                "label_key": "class_label",
             },
         },
         {
@@ -448,7 +468,7 @@ def test_confusion_matrix_multiclass(
                     "bee": {"count": 1, "examples": [{"datum": "uid1"}]},
                 },
             },
-            "parameters": {"score_threshold": 0.5, "label_key": "class_label"},
+            "parameters": {"score_threshold": 0.5},
         },
         {
             "type": "ConfusionMatrix",
@@ -468,7 +488,6 @@ def test_confusion_matrix_multiclass(
             },
             "parameters": {
                 "score_threshold": 0.85,
-                "label_key": "class_label",
             },
         },
     ]
@@ -482,25 +501,22 @@ def test_confusion_matrix_multiclass(
         assert m in actual_metrics
 
 
-def test_confusion_matrix_without_hardmax(
-    classifications_multiclass_true_negatives_check: list[Classification],
+def test_confusion_matrix_without_hardmax_animal_example(
+    classifications_multiclass_true_negatives_check_animals: list[
+        Classification
+    ],
 ):
     loader = DataLoader()
-    loader.add_data(classifications_multiclass_true_negatives_check)
+    loader.add_data(classifications_multiclass_true_negatives_check_animals)
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
-        "ignored_prediction_labels": [
-            ("k1", "bee"),
-            ("k1", "cat"),
-            ("k2", "milk"),
-            ("k2", "flour"),
-        ],
+        "n_datums": 1,
+        "n_groundtruths": 1,
+        "n_predictions": 3,
+        "n_labels": 3,
+        "ignored_prediction_labels": ["bee", "cat"],
         "missing_prediction_labels": [],
-        "n_datums": 2,
-        "n_groundtruths": 2,
-        "n_labels": 6,
-        "n_predictions": 6,
     }
 
     metrics = evaluator.evaluate(
@@ -511,7 +527,6 @@ def test_confusion_matrix_without_hardmax(
         as_dict=True,
     )
 
-    # test ConfusionMatrix
     actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
     expected_metrics = [
         {
@@ -541,7 +556,7 @@ def test_confusion_matrix_without_hardmax(
                 },
                 "missing_predictions": {},
             },
-            "parameters": {"score_threshold": 0.05, "label_key": "k1"},
+            "parameters": {"score_threshold": 0.05},
         },
         {
             "type": "ConfusionMatrix",
@@ -558,7 +573,7 @@ def test_confusion_matrix_without_hardmax(
                 },
                 "missing_predictions": {},
             },
-            "parameters": {"score_threshold": 0.4, "label_key": "k1"},
+            "parameters": {"score_threshold": 0.4},
         },
         {
             "type": "ConfusionMatrix",
@@ -575,8 +590,48 @@ def test_confusion_matrix_without_hardmax(
                     }
                 },
             },
-            "parameters": {"score_threshold": 0.5, "label_key": "k1"},
+            "parameters": {"score_threshold": 0.5},
         },
+    ]
+    for m in actual_metrics:
+        _filter_elements_with_zero_count(
+            cm=m["value"]["confusion_matrix"],
+            mp=m["value"]["missing_predictions"],
+        )
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_confusion_matrix_without_hardmax_ingredient_example(
+    classifications_multiclass_true_negatives_check_ingredients: list[
+        Classification
+    ],
+):
+    loader = DataLoader()
+    loader.add_data(
+        classifications_multiclass_true_negatives_check_ingredients
+    )
+    evaluator = loader.finalize()
+
+    assert evaluator.metadata == {
+        "n_datums": 1,
+        "n_groundtruths": 1,
+        "n_predictions": 3,
+        "n_labels": 3,
+        "ignored_prediction_labels": ["milk", "flour"],
+        "missing_prediction_labels": [],
+    }
+    metrics = evaluator.evaluate(
+        metrics_to_return=[MetricType.ConfusionMatrix],
+        score_thresholds=[0.05, 0.4, 0.5],
+        number_of_examples=6,
+        hardmax=False,
+        as_dict=True,
+    )
+
+    actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
+    expected_metrics = [
         {
             "type": "ConfusionMatrix",
             "value": {
@@ -604,7 +659,7 @@ def test_confusion_matrix_without_hardmax(
                 },
                 "missing_predictions": {},
             },
-            "parameters": {"score_threshold": 0.05, "label_key": "k2"},
+            "parameters": {"score_threshold": 0.05},
         },
         {
             "type": "ConfusionMatrix",
@@ -621,7 +676,7 @@ def test_confusion_matrix_without_hardmax(
                 },
                 "missing_predictions": {},
             },
-            "parameters": {"score_threshold": 0.4, "label_key": "k2"},
+            "parameters": {"score_threshold": 0.4},
         },
         {
             "type": "ConfusionMatrix",
@@ -638,7 +693,7 @@ def test_confusion_matrix_without_hardmax(
                     }
                 },
             },
-            "parameters": {"score_threshold": 0.5, "label_key": "k2"},
+            "parameters": {"score_threshold": 0.5},
         },
     ]
     for m in actual_metrics:

--- a/lite/tests/classification/test_confusion_matrix.py
+++ b/lite/tests/classification/test_confusion_matrix.py
@@ -502,12 +502,10 @@ def test_confusion_matrix_multiclass(
 
 
 def test_confusion_matrix_without_hardmax_animal_example(
-    classifications_multiclass_true_negatives_check_animals: list[
-        Classification
-    ],
+    classifications_multiclass_true_negatives_check: list[Classification],
 ):
     loader = DataLoader()
-    loader.add_data(classifications_multiclass_true_negatives_check_animals)
+    loader.add_data(classifications_multiclass_true_negatives_check)
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
@@ -585,109 +583,6 @@ def test_confusion_matrix_without_hardmax_animal_example(
                         "examples": [
                             {
                                 "datum": "uid1",
-                            }
-                        ],
-                    }
-                },
-            },
-            "parameters": {"score_threshold": 0.5},
-        },
-    ]
-    for m in actual_metrics:
-        _filter_elements_with_zero_count(
-            cm=m["value"]["confusion_matrix"],
-            mp=m["value"]["missing_predictions"],
-        )
-        assert m in expected_metrics
-    for m in expected_metrics:
-        assert m in actual_metrics
-
-
-def test_confusion_matrix_without_hardmax_ingredient_example(
-    classifications_multiclass_true_negatives_check_ingredients: list[
-        Classification
-    ],
-):
-    loader = DataLoader()
-    loader.add_data(
-        classifications_multiclass_true_negatives_check_ingredients
-    )
-    evaluator = loader.finalize()
-
-    assert evaluator.metadata == {
-        "n_datums": 1,
-        "n_groundtruths": 1,
-        "n_predictions": 3,
-        "n_labels": 3,
-        "ignored_prediction_labels": ["milk", "flour"],
-        "missing_prediction_labels": [],
-    }
-    metrics = evaluator.evaluate(
-        metrics_to_return=[MetricType.ConfusionMatrix],
-        score_thresholds=[0.05, 0.4, 0.5],
-        number_of_examples=6,
-        hardmax=False,
-        as_dict=True,
-    )
-
-    actual_metrics = [m for m in metrics[MetricType.ConfusionMatrix]]
-    expected_metrics = [
-        {
-            "type": "ConfusionMatrix",
-            "value": {
-                "confusion_matrix": {
-                    "egg": {
-                        "egg": {
-                            "count": 1,
-                            "examples": [
-                                {"datum": "uid2", "score": 0.15000000596046448}
-                            ],
-                        },
-                        "milk": {
-                            "count": 1,
-                            "examples": [
-                                {"datum": "uid2", "score": 0.47999998927116394}
-                            ],
-                        },
-                        "flour": {
-                            "count": 1,
-                            "examples": [
-                                {"datum": "uid2", "score": 0.3700000047683716}
-                            ],
-                        },
-                    }
-                },
-                "missing_predictions": {},
-            },
-            "parameters": {"score_threshold": 0.05},
-        },
-        {
-            "type": "ConfusionMatrix",
-            "value": {
-                "confusion_matrix": {
-                    "egg": {
-                        "milk": {
-                            "count": 1,
-                            "examples": [
-                                {"datum": "uid2", "score": 0.47999998927116394}
-                            ],
-                        },
-                    }
-                },
-                "missing_predictions": {},
-            },
-            "parameters": {"score_threshold": 0.4},
-        },
-        {
-            "type": "ConfusionMatrix",
-            "value": {
-                "confusion_matrix": {},
-                "missing_predictions": {
-                    "egg": {
-                        "count": 1,
-                        "examples": [
-                            {
-                                "datum": "uid2",
                             }
                         ],
                     }

--- a/lite/tests/classification/test_counts.py
+++ b/lite/tests/classification/test_counts.py
@@ -618,12 +618,10 @@ def test_counts_multiclass(
 
 
 def test_counts_true_negatives_check_animals(
-    classifications_multiclass_true_negatives_check_animals: list[
-        Classification
-    ],
+    classifications_multiclass_true_negatives_check: list[Classification],
 ):
     loader = DataLoader()
-    loader.add_data(classifications_multiclass_true_negatives_check_animals)
+    loader.add_data(classifications_multiclass_true_negatives_check)
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
@@ -680,82 +678,6 @@ def test_counts_true_negatives_check_animals(
                 "score_thresholds": [0.05, 0.15, 0.95],
                 "hardmax": True,
                 "label": "cat",
-            },
-            "type": "Counts",
-        },
-    ]
-    for m in actual_metrics:
-        assert m in expected_metrics
-    for m in expected_metrics:
-        assert m in actual_metrics
-
-
-def test_counts_true_negatives_check_ingredients(
-    classifications_multiclass_true_negatives_check_ingredients: list[
-        Classification
-    ],
-):
-    loader = DataLoader()
-    loader.add_data(
-        classifications_multiclass_true_negatives_check_ingredients
-    )
-    evaluator = loader.finalize()
-
-    assert evaluator.metadata == {
-        "n_datums": 1,
-        "n_groundtruths": 1,
-        "n_predictions": 3,
-        "n_labels": 3,
-        "ignored_prediction_labels": ["milk", "flour"],
-        "missing_prediction_labels": [],
-    }
-
-    metrics = evaluator.evaluate(
-        score_thresholds=[0.05, 0.15, 0.95],
-        as_dict=True,
-    )
-
-    actual_metrics = [m for m in metrics[MetricType.Counts]]
-    expected_metrics = [
-        {
-            "value": {
-                "tp": [0, 0, 0],
-                "fp": [0, 0, 0],
-                "fn": [1, 1, 1],
-                "tn": [0, 0, 0],
-            },
-            "parameters": {
-                "score_thresholds": [0.05, 0.15, 0.95],
-                "hardmax": True,
-                "label": "egg",
-            },
-            "type": "Counts",
-        },
-        {
-            "value": {
-                "tp": [0, 0, 0],
-                "fp": [1, 1, 0],
-                "fn": [0, 0, 0],
-                "tn": [0, 0, 1],
-            },
-            "parameters": {
-                "score_thresholds": [0.05, 0.15, 0.95],
-                "hardmax": True,
-                "label": "milk",
-            },
-            "type": "Counts",
-        },
-        {
-            "value": {
-                "tp": [0, 0, 0],
-                "fp": [0, 0, 0],
-                "fn": [0, 0, 0],
-                "tn": [1, 1, 1],
-            },
-            "parameters": {
-                "score_thresholds": [0.05, 0.15, 0.95],
-                "hardmax": True,
-                "label": "flour",
             },
             "type": "Counts",
         },

--- a/lite/tests/classification/test_counts.py
+++ b/lite/tests/classification/test_counts.py
@@ -114,10 +114,7 @@ def test_counts_basic(basic_classifications: list[Classification]):
         "n_groundtruths": 3,
         "n_predictions": 12,
         "n_labels": 4,
-        "ignored_prediction_labels": [
-            ("class", "1"),
-            ("class", "2"),
-        ],
+        "ignored_prediction_labels": ["1", "2"],
         "missing_prediction_labels": [],
     }
 
@@ -126,7 +123,6 @@ def test_counts_basic(basic_classifications: list[Classification]):
         as_dict=True,
     )
 
-    # test Counts
     actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
@@ -140,7 +136,7 @@ def test_counts_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -154,7 +150,7 @@ def test_counts_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -168,7 +164,7 @@ def test_counts_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
         {
@@ -182,7 +178,7 @@ def test_counts_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "3"},
+                "label": "3",
             },
         },
     ]
@@ -205,7 +201,6 @@ def test_counts_unit(
         as_dict=True,
     )
 
-    # test Counts
     actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
@@ -219,7 +214,7 @@ def test_counts_unit(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -233,7 +228,7 @@ def test_counts_unit(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -247,7 +242,7 @@ def test_counts_unit(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
     ]
@@ -257,12 +252,12 @@ def test_counts_unit(
         assert m in actual_metrics
 
 
-def test_counts_with_example(
-    classifications_two_categories: list[Classification],
+def test_counts_with_animal_example(
+    classifications_animal_example: list[Classification],
 ):
 
     loader = DataLoader()
-    loader.add_data(classifications_two_categories)
+    loader.add_data(classifications_animal_example)
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(
@@ -270,7 +265,6 @@ def test_counts_with_example(
         as_dict=True,
     )
 
-    # test Counts
     actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
@@ -284,7 +278,7 @@ def test_counts_with_example(
             "parameters": {
                 "score_thresholds": [0.05, 0.5, 0.95],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "bird"},
+                "label": "bird",
             },
         },
         {
@@ -298,7 +292,7 @@ def test_counts_with_example(
             "parameters": {
                 "score_thresholds": [0.05, 0.5, 0.95],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "dog"},
+                "label": "dog",
             },
         },
         {
@@ -312,9 +306,31 @@ def test_counts_with_example(
             "parameters": {
                 "score_thresholds": [0.05, 0.5, 0.95],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "cat"},
+                "label": "cat",
             },
         },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_counts_with_color_example(
+    classifications_color_example: list[Classification],
+):
+
+    loader = DataLoader()
+    loader.add_data(classifications_color_example)
+    evaluator = loader.finalize()
+
+    metrics = evaluator.evaluate(
+        score_thresholds=[0.05, 0.5, 0.95],
+        as_dict=True,
+    )
+
+    actual_metrics = [m for m in metrics[MetricType.Counts]]
+    expected_metrics = [
         {
             "type": "Counts",
             "value": {
@@ -326,7 +342,7 @@ def test_counts_with_example(
             "parameters": {
                 "score_thresholds": [0.05, 0.5, 0.95],
                 "hardmax": True,
-                "label": {"key": "color", "value": "white"},
+                "label": "white",
             },
         },
         {
@@ -340,7 +356,7 @@ def test_counts_with_example(
             "parameters": {
                 "score_thresholds": [0.05, 0.5, 0.95],
                 "hardmax": True,
-                "label": {"key": "color", "value": "red"},
+                "label": "red",
             },
         },
         {
@@ -354,7 +370,7 @@ def test_counts_with_example(
             "parameters": {
                 "score_thresholds": [0.05, 0.5, 0.95],
                 "hardmax": True,
-                "label": {"key": "color", "value": "blue"},
+                "label": "blue",
             },
         },
         {
@@ -368,7 +384,7 @@ def test_counts_with_example(
             "parameters": {
                 "score_thresholds": [0.05, 0.5, 0.95],
                 "hardmax": True,
-                "label": {"key": "color", "value": "black"},
+                "label": "black",
             },
         },
     ]
@@ -386,58 +402,17 @@ def test_counts_with_image_example(
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
-        "n_datums": 3,
-        "n_groundtruths": 4,
-        "n_predictions": 6,
-        "n_labels": 8,
-        "ignored_prediction_labels": [
-            ("k4", "v1"),
-            ("k4", "v8"),
-            ("k5", "v1"),
-            ("k4", "v5"),
-            ("k3", "v1"),
-        ],
-        "missing_prediction_labels": [
-            ("k5", "v5"),
-            ("k3", "v3"),
-        ],
+        "n_datums": 2,
+        "n_groundtruths": 2,
+        "n_predictions": 4,
+        "n_labels": 4,
+        "ignored_prediction_labels": ["v1", "v8", "v5"],
+        "missing_prediction_labels": [],
     }
-
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test Counts
     actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
-        # k3
-        {
-            "type": "Counts",
-            "value": {
-                "tp": [0],
-                "fp": [1],
-                "fn": [0],
-                "tn": [0],
-            },
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k3", "value": "v1"},
-            },
-        },
-        {
-            "type": "Counts",
-            "value": {
-                "tp": [0],
-                "fp": [0],
-                "fn": [1],
-                "tn": [0],
-            },
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k3", "value": "v3"},
-            },
-        },
-        # k4
         {
             "type": "Counts",
             "value": {
@@ -449,7 +424,7 @@ def test_counts_with_image_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "k4", "value": "v1"},
+                "label": "v1",
             },
         },
         {
@@ -463,7 +438,7 @@ def test_counts_with_image_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "k4", "value": "v4"},
+                "label": "v4",
             },
         },
         {
@@ -477,7 +452,7 @@ def test_counts_with_image_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "k4", "value": "v5"},
+                "label": "v5",
             },
         },
         {
@@ -491,36 +466,7 @@ def test_counts_with_image_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "k4", "value": "v8"},
-            },
-        },
-        # k5
-        {
-            "type": "Counts",
-            "value": {
-                "tp": [0],
-                "fp": [1],
-                "fn": [0],
-                "tn": [0],
-            },
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k5", "value": "v1"},
-            },
-        },
-        {
-            "type": "Counts",
-            "value": {
-                "tp": [0],
-                "fp": [0],
-                "fn": [1],
-                "tn": [0],
-            },
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k5", "value": "v5"},
+                "label": "v8",
             },
         },
     ]
@@ -548,7 +494,6 @@ def test_counts_with_tabular_example(
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test Counts
     actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
@@ -562,7 +507,7 @@ def test_counts_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -576,7 +521,7 @@ def test_counts_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -590,7 +535,7 @@ def test_counts_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
     ]
@@ -621,7 +566,6 @@ def test_counts_multiclass(
         as_dict=True,
     )
 
-    # test Counts
     actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
@@ -634,7 +578,7 @@ def test_counts_multiclass(
             "parameters": {
                 "score_thresholds": [0.05, 0.1, 0.3, 0.85],
                 "hardmax": True,
-                "label": {"key": "class_label", "value": "cat"},
+                "label": "cat",
             },
             "type": "Counts",
         },
@@ -648,7 +592,7 @@ def test_counts_multiclass(
             "parameters": {
                 "score_thresholds": [0.05, 0.1, 0.3, 0.85],
                 "hardmax": True,
-                "label": {"key": "class_label", "value": "dog"},
+                "label": "dog",
             },
             "type": "Counts",
         },
@@ -662,7 +606,7 @@ def test_counts_multiclass(
             "parameters": {
                 "score_thresholds": [0.05, 0.1, 0.3, 0.85],
                 "hardmax": True,
-                "label": {"key": "class_label", "value": "bee"},
+                "label": "bee",
             },
             "type": "Counts",
         },
@@ -673,33 +617,28 @@ def test_counts_multiclass(
         assert m in actual_metrics
 
 
-def test_counts_true_negatives_check(
-    classifications_multiclass_true_negatives_check: list[Classification],
+def test_counts_true_negatives_check_animals(
+    classifications_multiclass_true_negatives_check_animals: list[
+        Classification
+    ],
 ):
     loader = DataLoader()
-    loader.add_data(classifications_multiclass_true_negatives_check)
+    loader.add_data(classifications_multiclass_true_negatives_check_animals)
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
-        "ignored_prediction_labels": [
-            ("k1", "bee"),
-            ("k1", "cat"),
-            ("k2", "milk"),
-            ("k2", "flour"),
-        ],
+        "n_datums": 1,
+        "n_groundtruths": 1,
+        "n_predictions": 3,
+        "n_labels": 3,
+        "ignored_prediction_labels": ["bee", "cat"],
         "missing_prediction_labels": [],
-        "n_datums": 2,
-        "n_groundtruths": 2,
-        "n_labels": 6,
-        "n_predictions": 6,
     }
-
     metrics = evaluator.evaluate(
         score_thresholds=[0.05, 0.15, 0.95],
         as_dict=True,
     )
 
-    # test Counts
     actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
@@ -712,7 +651,7 @@ def test_counts_true_negatives_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.15, 0.95],
                 "hardmax": True,
-                "label": {"key": "k1", "value": "ant"},
+                "label": "ant",
             },
             "type": "Counts",
         },
@@ -726,7 +665,7 @@ def test_counts_true_negatives_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.15, 0.95],
                 "hardmax": True,
-                "label": {"key": "k1", "value": "bee"},
+                "label": "bee",
             },
             "type": "Counts",
         },
@@ -740,10 +679,44 @@ def test_counts_true_negatives_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.15, 0.95],
                 "hardmax": True,
-                "label": {"key": "k1", "value": "cat"},
+                "label": "cat",
             },
             "type": "Counts",
         },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_counts_true_negatives_check_ingredients(
+    classifications_multiclass_true_negatives_check_ingredients: list[
+        Classification
+    ],
+):
+    loader = DataLoader()
+    loader.add_data(
+        classifications_multiclass_true_negatives_check_ingredients
+    )
+    evaluator = loader.finalize()
+
+    assert evaluator.metadata == {
+        "n_datums": 1,
+        "n_groundtruths": 1,
+        "n_predictions": 3,
+        "n_labels": 3,
+        "ignored_prediction_labels": ["milk", "flour"],
+        "missing_prediction_labels": [],
+    }
+
+    metrics = evaluator.evaluate(
+        score_thresholds=[0.05, 0.15, 0.95],
+        as_dict=True,
+    )
+
+    actual_metrics = [m for m in metrics[MetricType.Counts]]
+    expected_metrics = [
         {
             "value": {
                 "tp": [0, 0, 0],
@@ -754,7 +727,7 @@ def test_counts_true_negatives_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.15, 0.95],
                 "hardmax": True,
-                "label": {"key": "k2", "value": "egg"},
+                "label": "egg",
             },
             "type": "Counts",
         },
@@ -768,7 +741,7 @@ def test_counts_true_negatives_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.15, 0.95],
                 "hardmax": True,
-                "label": {"key": "k2", "value": "milk"},
+                "label": "milk",
             },
             "type": "Counts",
         },
@@ -782,7 +755,7 @@ def test_counts_true_negatives_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.15, 0.95],
                 "hardmax": True,
-                "label": {"key": "k2", "value": "flour"},
+                "label": "flour",
             },
             "type": "Counts",
         },
@@ -802,10 +775,7 @@ def test_counts_zero_count_check(
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
-        "ignored_prediction_labels": [
-            ("k", "bee"),
-            ("k", "cat"),
-        ],
+        "ignored_prediction_labels": ["bee", "cat"],
         "missing_prediction_labels": [],
         "n_datums": 1,
         "n_groundtruths": 1,
@@ -818,7 +788,6 @@ def test_counts_zero_count_check(
         as_dict=True,
     )
 
-    # test Counts
     actual_metrics = [m for m in metrics[MetricType.Counts]]
     expected_metrics = [
         {
@@ -831,7 +800,7 @@ def test_counts_zero_count_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.2, 0.95],
                 "hardmax": True,
-                "label": {"key": "k", "value": "ant"},
+                "label": "ant",
             },
             "type": "Counts",
         },
@@ -845,7 +814,7 @@ def test_counts_zero_count_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.2, 0.95],
                 "hardmax": True,
-                "label": {"key": "k", "value": "bee"},
+                "label": "bee",
             },
             "type": "Counts",
         },
@@ -859,7 +828,7 @@ def test_counts_zero_count_check(
             "parameters": {
                 "score_thresholds": [0.05, 0.2, 0.95],
                 "hardmax": True,
-                "label": {"key": "k", "value": "cat"},
+                "label": "cat",
             },
             "type": "Counts",
         },

--- a/lite/tests/classification/test_dataloader.py
+++ b/lite/tests/classification/test_dataloader.py
@@ -24,26 +24,26 @@ def test_valor_integration():
 
     assert loader._evaluator._detailed_pairs.shape == (10, 5)
 
-    assert set(loader._evaluator.label_key_to_index.keys()) == {
-        "class_label",
-    }
     assert len(loader._evaluator.index_to_label) == 11
     assert loader._evaluator.n_datums == 1
 
 
-def test_mismatch_label_keys(
+def test_missing_groundtruths_or_predictions(
     classifications_no_groundtruths: list[Classification],
     classifications_no_predictions: list[Classification],
-    classifications_with_label_key_mismatch: list[Classification],
 ):
     loader = DataLoader()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         loader.add_data(classifications_no_groundtruths)
-
-    with pytest.raises(ValueError):
-        loader.add_data(classifications_no_predictions)
+    assert (
+        "Classifications must contain at least one groundtruth and prediction"
+        in str(e)
+    )
 
     with pytest.raises(ValueError) as e:
-        loader.add_data(classifications_with_label_key_mismatch)
-    assert "Label keys must match" in str(e)
+        loader.add_data(classifications_no_predictions)
+    assert (
+        "Classifications must contain at least one groundtruth and prediction"
+        in str(e)
+    )

--- a/lite/tests/classification/test_evaluator.py
+++ b/lite/tests/classification/test_evaluator.py
@@ -2,24 +2,24 @@ from valor_lite.classification import Classification, DataLoader
 
 
 def test_metadata_using_classification_example(
-    classifications_two_categories: list[Classification],
+    classifications_animal_example: list[Classification],
 ):
     manager = DataLoader()
-    manager.add_data(classifications_two_categories)
+    manager.add_data(classifications_animal_example)
     evaluator = manager.finalize()
 
     assert evaluator.ignored_prediction_labels == []
     assert evaluator.missing_prediction_labels == []
     assert evaluator.n_datums == 6
-    assert evaluator.n_labels == 7
-    assert evaluator.n_groundtruths == 12
-    assert evaluator.n_predictions == 7 * 6
+    assert evaluator.n_labels == 3
+    assert evaluator.n_groundtruths == 6
+    assert evaluator.n_predictions == 3 * 6
 
     assert evaluator.metadata == {
+        "n_datums": 6,
+        "n_groundtruths": 6,
+        "n_predictions": 3 * 6,
+        "n_labels": 3,
         "ignored_prediction_labels": [],
         "missing_prediction_labels": [],
-        "n_datums": 6,
-        "n_labels": 7,
-        "n_groundtruths": 12,
-        "n_predictions": 7 * 6,
     }

--- a/lite/tests/classification/test_f1.py
+++ b/lite/tests/classification/test_f1.py
@@ -77,10 +77,7 @@ def test_f1_score_basic(basic_classifications: list[Classification]):
         "n_groundtruths": 3,
         "n_predictions": 12,
         "n_labels": 4,
-        "ignored_prediction_labels": [
-            ("class", "1"),
-            ("class", "2"),
-        ],
+        "ignored_prediction_labels": ["1", "2"],
         "missing_prediction_labels": [],
     }
 
@@ -89,7 +86,6 @@ def test_f1_score_basic(basic_classifications: list[Classification]):
         as_dict=True,
     )
 
-    # test F1
     actual_metrics = [m for m in metrics[MetricType.F1]]
     expected_metrics = [
         {
@@ -98,7 +94,7 @@ def test_f1_score_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -107,7 +103,7 @@ def test_f1_score_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "3"},
+                "label": "3",
             },
         },
     ]
@@ -117,12 +113,12 @@ def test_f1_score_basic(basic_classifications: list[Classification]):
         assert m in actual_metrics
 
 
-def test_f1_score_with_example(
-    classifications_two_categories: list[Classification],
+def test_f1_score_with_animal_example(
+    classifications_animal_example: list[Classification],
 ):
 
     loader = DataLoader()
-    loader.add_data(classifications_two_categories)
+    loader.add_data(classifications_animal_example)
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(
@@ -130,7 +126,6 @@ def test_f1_score_with_example(
         as_dict=True,
     )
 
-    # test F1
     actual_metrics = [m for m in metrics[MetricType.F1]]
     expected_metrics = [
         {
@@ -139,7 +134,7 @@ def test_f1_score_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "bird"},
+                "label": "bird",
             },
         },
         {
@@ -148,7 +143,7 @@ def test_f1_score_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "dog"},
+                "label": "dog",
             },
         },
         {
@@ -157,16 +152,38 @@ def test_f1_score_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "cat"},
+                "label": "cat",
             },
         },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_f1_score_with_color_example(
+    classifications_color_example: list[Classification],
+):
+
+    loader = DataLoader()
+    loader.add_data(classifications_color_example)
+    evaluator = loader.finalize()
+
+    metrics = evaluator.evaluate(
+        score_thresholds=[0.0, 0.5],
+        as_dict=True,
+    )
+
+    actual_metrics = [m for m in metrics[MetricType.F1]]
+    expected_metrics = [
         {
             "type": "F1",
             "value": [0.5, 0.5],
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "white"},
+                "label": "white",
             },
         },
         {
@@ -175,7 +192,7 @@ def test_f1_score_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "red"},
+                "label": "red",
             },
         },
         {
@@ -184,7 +201,7 @@ def test_f1_score_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "blue"},
+                "label": "blue",
             },
         },
         {
@@ -193,7 +210,7 @@ def test_f1_score_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "black"},
+                "label": "black",
             },
         },
     ]
@@ -211,26 +228,16 @@ def test_f1_score_with_image_example(
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
-        "n_datums": 3,
-        "n_groundtruths": 4,
-        "n_predictions": 6,
-        "n_labels": 8,
-        "ignored_prediction_labels": [
-            ("k4", "v1"),
-            ("k4", "v8"),
-            ("k5", "v1"),
-            ("k4", "v5"),
-            ("k3", "v1"),
-        ],
-        "missing_prediction_labels": [
-            ("k5", "v5"),
-            ("k3", "v3"),
-        ],
+        "n_datums": 2,
+        "n_groundtruths": 2,
+        "n_predictions": 4,
+        "n_labels": 4,
+        "ignored_prediction_labels": ["v1", "v8", "v5"],
+        "missing_prediction_labels": [],
     }
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test F1
     actual_metrics = [m for m in metrics[MetricType.F1]]
     expected_metrics = [
         {
@@ -239,25 +246,7 @@ def test_f1_score_with_image_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "k4", "value": "v4"},
-            },
-        },
-        {
-            "type": "F1",
-            "value": [0.0],
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k5", "value": "v5"},
-            },
-        },
-        {
-            "type": "F1",
-            "value": [0.0],
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k3", "value": "v3"},
+                "label": "v4",
             },
         },
     ]
@@ -285,7 +274,6 @@ def test_f1_score_with_tabular_example(
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test F1
     actual_metrics = [m for m in metrics[MetricType.F1]]
     expected_metrics = [
         {
@@ -294,7 +282,7 @@ def test_f1_score_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -303,7 +291,7 @@ def test_f1_score_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -312,7 +300,7 @@ def test_f1_score_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
     ]

--- a/lite/tests/classification/test_precision.py
+++ b/lite/tests/classification/test_precision.py
@@ -77,10 +77,7 @@ def test_precision_basic(basic_classifications: list[Classification]):
         "n_groundtruths": 3,
         "n_predictions": 12,
         "n_labels": 4,
-        "ignored_prediction_labels": [
-            ("class", "1"),
-            ("class", "2"),
-        ],
+        "ignored_prediction_labels": ["1", "2"],
         "missing_prediction_labels": [],
     }
 
@@ -89,7 +86,6 @@ def test_precision_basic(basic_classifications: list[Classification]):
         as_dict=True,
     )
 
-    # test Precision
     actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
@@ -98,7 +94,7 @@ def test_precision_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -107,7 +103,7 @@ def test_precision_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "3"},
+                "label": "3",
             },
         },
     ]
@@ -117,11 +113,11 @@ def test_precision_basic(basic_classifications: list[Classification]):
         assert m in actual_metrics
 
 
-def test_precision_with_example(
-    classifications_two_categories: list[Classification],
+def test_precision_with_animal_example(
+    classifications_animal_example: list[Classification],
 ):
     loader = DataLoader()
-    loader.add_data(classifications_two_categories)
+    loader.add_data(classifications_animal_example)
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(
@@ -129,7 +125,6 @@ def test_precision_with_example(
         as_dict=True,
     )
 
-    # test Precision
     actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
@@ -138,7 +133,7 @@ def test_precision_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "bird"},
+                "label": "bird",
             },
         },
         {
@@ -147,7 +142,7 @@ def test_precision_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "dog"},
+                "label": "dog",
             },
         },
         {
@@ -156,16 +151,37 @@ def test_precision_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "cat"},
+                "label": "cat",
             },
         },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_precision_with_color_example(
+    classifications_color_example: list[Classification],
+):
+    loader = DataLoader()
+    loader.add_data(classifications_color_example)
+    evaluator = loader.finalize()
+
+    metrics = evaluator.evaluate(
+        score_thresholds=[0.0, 0.5],
+        as_dict=True,
+    )
+
+    actual_metrics = [m for m in metrics[MetricType.Precision]]
+    expected_metrics = [
         {
             "type": "Precision",
             "value": [0.5, 0.5],
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "white"},
+                "label": "white",
             },
         },
         {
@@ -174,7 +190,7 @@ def test_precision_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "red"},
+                "label": "red",
             },
         },
         {
@@ -183,7 +199,7 @@ def test_precision_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "blue"},
+                "label": "blue",
             },
         },
         {
@@ -192,7 +208,7 @@ def test_precision_with_example(
             "parameters": {
                 "score_thresholds": [0.0, 0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "black"},
+                "label": "black",
             },
         },
     ]
@@ -210,26 +226,16 @@ def test_precision_with_image_example(
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
-        "n_datums": 3,
-        "n_groundtruths": 4,
-        "n_predictions": 6,
-        "n_labels": 8,
-        "ignored_prediction_labels": [
-            ("k4", "v1"),
-            ("k4", "v8"),
-            ("k5", "v1"),
-            ("k4", "v5"),
-            ("k3", "v1"),
-        ],
-        "missing_prediction_labels": [
-            ("k5", "v5"),
-            ("k3", "v3"),
-        ],
+        "n_datums": 2,
+        "n_groundtruths": 2,
+        "n_predictions": 4,
+        "n_labels": 4,
+        "ignored_prediction_labels": ["v1", "v8", "v5"],
+        "missing_prediction_labels": [],
     }
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test Precision
     actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
@@ -238,25 +244,7 @@ def test_precision_with_image_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "k4", "value": "v4"},
-            },
-        },
-        {
-            "type": "Precision",
-            "value": [0.0],
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k5", "value": "v5"},
-            },
-        },
-        {
-            "type": "Precision",
-            "value": [0.0],
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k3", "value": "v3"},
+                "label": "v4",
             },
         },
     ]
@@ -284,7 +272,6 @@ def test_precision_with_tabular_example(
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test Precision
     actual_metrics = [m for m in metrics[MetricType.Precision]]
     expected_metrics = [
         {
@@ -293,7 +280,7 @@ def test_precision_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -302,7 +289,7 @@ def test_precision_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -311,7 +298,7 @@ def test_precision_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
     ]

--- a/lite/tests/classification/test_recall.py
+++ b/lite/tests/classification/test_recall.py
@@ -77,10 +77,7 @@ def test_recall_basic(basic_classifications: list[Classification]):
         "n_groundtruths": 3,
         "n_predictions": 12,
         "n_labels": 4,
-        "ignored_prediction_labels": [
-            ("class", "1"),
-            ("class", "2"),
-        ],
+        "ignored_prediction_labels": ["1", "2"],
         "missing_prediction_labels": [],
     }
 
@@ -89,7 +86,6 @@ def test_recall_basic(basic_classifications: list[Classification]):
         as_dict=True,
     )
 
-    # test Recall
     actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
@@ -98,7 +94,7 @@ def test_recall_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -107,7 +103,7 @@ def test_recall_basic(basic_classifications: list[Classification]):
             "parameters": {
                 "score_thresholds": [0.25, 0.75],
                 "hardmax": True,
-                "label": {"key": "class", "value": "3"},
+                "label": "3",
             },
         },
     ]
@@ -117,12 +113,12 @@ def test_recall_basic(basic_classifications: list[Classification]):
         assert m in actual_metrics
 
 
-def test_recall_with_example(
-    classifications_two_categories: list[Classification],
+def test_recall_with_animal_example(
+    classifications_animal_example: list[Classification],
 ):
 
     loader = DataLoader()
-    loader.add_data(classifications_two_categories)
+    loader.add_data(classifications_animal_example)
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(
@@ -130,7 +126,6 @@ def test_recall_with_example(
         as_dict=True,
     )
 
-    # test Recall
     actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
@@ -139,7 +134,7 @@ def test_recall_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "bird"},
+                "label": "bird",
             },
         },
         {
@@ -148,7 +143,7 @@ def test_recall_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "dog"},
+                "label": "dog",
             },
         },
         {
@@ -157,7 +152,38 @@ def test_recall_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "animal", "value": "cat"},
+                "label": "cat",
+            },
+        },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_recall_with_color_example(
+    classifications_color_example: list[Classification],
+):
+
+    loader = DataLoader()
+    loader.add_data(classifications_color_example)
+    evaluator = loader.finalize()
+
+    metrics = evaluator.evaluate(
+        score_thresholds=[0.5],
+        as_dict=True,
+    )
+
+    actual_metrics = [m for m in metrics[MetricType.Recall]]
+    expected_metrics = [
+        {
+            "type": "Recall",
+            "value": [0.5],
+            "parameters": {
+                "score_thresholds": [0.5],
+                "hardmax": True,
+                "label": "white",
             },
         },
         {
@@ -166,16 +192,7 @@ def test_recall_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "white"},
-            },
-        },
-        {
-            "type": "Recall",
-            "value": [0.5],
-            "parameters": {
-                "score_thresholds": [0.5],
-                "hardmax": True,
-                "label": {"key": "color", "value": "red"},
+                "label": "red",
             },
         },
         {
@@ -184,7 +201,7 @@ def test_recall_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "blue"},
+                "label": "blue",
             },
         },
         {
@@ -193,7 +210,7 @@ def test_recall_with_example(
             "parameters": {
                 "score_thresholds": [0.5],
                 "hardmax": True,
-                "label": {"key": "color", "value": "black"},
+                "label": "black",
             },
         },
     ]
@@ -211,26 +228,16 @@ def test_recall_with_image_example(
     evaluator = loader.finalize()
 
     assert evaluator.metadata == {
-        "n_datums": 3,
-        "n_groundtruths": 4,
-        "n_predictions": 6,
-        "n_labels": 8,
-        "ignored_prediction_labels": [
-            ("k4", "v1"),
-            ("k4", "v8"),
-            ("k5", "v1"),
-            ("k4", "v5"),
-            ("k3", "v1"),
-        ],
-        "missing_prediction_labels": [
-            ("k5", "v5"),
-            ("k3", "v3"),
-        ],
+        "n_datums": 2,
+        "n_groundtruths": 2,
+        "n_predictions": 4,
+        "n_labels": 4,
+        "ignored_prediction_labels": ["v1", "v8", "v5"],
+        "missing_prediction_labels": [],
     }
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test Recall
     actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
@@ -239,25 +246,7 @@ def test_recall_with_image_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "k4", "value": "v4"},
-            },
-        },
-        {
-            "type": "Recall",
-            "value": [0.0],
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k5", "value": "v5"},
-            },
-        },
-        {
-            "type": "Recall",
-            "value": [0.0],
-            "parameters": {
-                "score_thresholds": [0.0],
-                "hardmax": True,
-                "label": {"key": "k3", "value": "v3"},
+                "label": "v4",
             },
         },
     ]
@@ -285,7 +274,6 @@ def test_recall_with_tabular_example(
 
     metrics = evaluator.evaluate(as_dict=True)
 
-    # test Recall
     actual_metrics = [m for m in metrics[MetricType.Recall]]
     expected_metrics = [
         {
@@ -294,7 +282,7 @@ def test_recall_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "0"},
+                "label": "0",
             },
         },
         {
@@ -303,7 +291,7 @@ def test_recall_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "1"},
+                "label": "1",
             },
         },
         {
@@ -312,7 +300,7 @@ def test_recall_with_tabular_example(
             "parameters": {
                 "score_thresholds": [0.0],
                 "hardmax": True,
-                "label": {"key": "class", "value": "2"},
+                "label": "2",
             },
         },
     ]

--- a/lite/tests/classification/test_rocauc.py
+++ b/lite/tests/classification/test_rocauc.py
@@ -3,7 +3,7 @@ from valor_lite.classification import Classification, DataLoader, MetricType
 from valor_lite.classification.computation import compute_metrics
 
 
-def test_compute_rocauc():
+def test_compute_rocauc_animals():
     """
     Test ROC auc computation. This agrees with scikit-learn: the code (whose data
     comes from classification_test_data)
@@ -16,16 +16,6 @@ def test_compute_rocauc():
         {"dog": 0.75, "cat": 0.1, "bird": 0.15},
         {"cat": 1.0, "dog": 0.0, "bird": 0.0},
         {"cat": 0.4, "dog": 0.4, "bird": 0.2},
-    ]
-
-    color_gts = ["white", "white", "red", "blue", "black", "red"]
-    color_preds = [
-        {"white": 0.65, "red": 0.1, "blue": 0.2, "black": 0.05},
-        {"blue": 0.5, "white": 0.3, "red": 0.0, "black": 0.2},
-        {"red": 0.4, "white": 0.2, "blue": 0.1, "black": 0.3},
-        {"white": 1.0, "red": 0.0, "blue": 0.0, "black": 0.0},
-        {"red": 0.8, "white": 0.0, "blue": 0.2, "black": 0.0},
-        {"red": 0.9, "white": 0.06, "blue": 0.01, "black": 0.03},
     ]
 
     ```
@@ -44,28 +34,17 @@ def test_compute_rocauc():
 
     print(roc_auc_score(y_true, y_score, multi_class="ovr"))
 
-    # for the "color" label key
-    y_true = [3, 3, 2, 1, 0, 2]
-    y_score = [
-        [0.05, 0.2, 0.1, 0.65],
-        [0.2, 0.5, 0.0, 0.3],
-        [0.3, 0.1, 0.4, 0.2],
-        [0.0, 0.0, 0.0, 1.0],
-        [0.0, 0.2, 0.8, 0.0],
-        [0.03, 0.01, 0.9, 0.06],
-    ]
     ```
 
     outputs:
 
     ```
     0.8009259259259259
-    0.43125
     ```
     """
 
     # groundtruth, prediction, score
-    animals_and_colors = np.array(
+    animals = np.array(
         [
             # (animal, bird)
             [0, 0, 0, 0.6, 0],
@@ -88,57 +67,25 @@ def test_compute_rocauc():
             [0, 1, 2, 0.4, 0],
             [0, 0, 2, 0.2, 0],
             [0, 0, 2, 0.1, 0],
-            # (color, white)
-            [0, 5, 3, 1.0, 0],
-            [0, 3, 3, 0.65, 0],
-            [0, 3, 3, 0.3, 0],
-            [0, 4, 3, 0.2, 0],
-            [0, 4, 3, 0.06, 0],
-            [0, 6, 3, 0.0, 0],
-            # (color, red)
-            [0, 4, 4, 0.9, 0],
-            [0, 6, 4, 0.8, 0],
-            [0, 3, 4, 0.1, 0],
-            [0, 4, 4, 0.4, 0],
-            [0, 3, 4, 0.0, 0],
-            [0, 5, 4, 0.0, 0],
-            # (color, blue)
-            [0, 3, 5, 0.5, 0],
-            [0, 3, 5, 0.2, 0],
-            [0, 6, 5, 0.2, 0],
-            [0, 4, 5, 0.1, 0],
-            [0, 4, 5, 0.01, 0],
-            [0, 5, 5, 0.0, 0],
-            # (color, black)
-            [0, 4, 6, 0.3, 0],
-            [0, 3, 6, 0.2, 0],
-            [0, 3, 6, 0.05, 0],
-            [0, 4, 6, 0.03, 0],
-            [0, 5, 6, 0.0, 0],
-            [0, 6, 6, 0.0, 0],
         ],
         dtype=np.float64,
     )
-    indices = np.argsort(-animals_and_colors[:, 3], axis=0)
-    animals_and_colors = animals_and_colors[indices]
+    indices = np.argsort(-animals[:, 3], axis=0)
+    animals = animals[indices]
 
     # create args
     label_metadata = np.array(
         [
-            [3, 6, 0],
-            [2, 6, 0],
-            [1, 6, 0],
-            [2, 6, 1],
-            [2, 6, 1],
-            [1, 6, 1],
-            [1, 6, 1],
+            [3, 6],
+            [2, 6],
+            [1, 6],
         ],
         dtype=np.int32,
     )
 
     # compute ROCAUC and mROCAUC
     (_, _, _, _, _, rocauc, mean_rocauc) = compute_metrics(
-        data=animals_and_colors,
+        data=animals,
         label_metadata=label_metadata,
         n_datums=6,
         score_thresholds=np.array([]),
@@ -150,24 +97,118 @@ def test_compute_rocauc():
     assert rocauc[0] == 0.7777777777777778  # (animal, bird)
     assert rocauc[1] == 0.625  # (animal, dog)
     assert rocauc[2] == 1.0  # (animal, cat)
-    assert rocauc[3] == 0.75  # (color, white)
-    assert rocauc[4] == 0.875  # (color, red)
-    assert rocauc[5] == 0.0  # (color, blue)
-    assert rocauc[6] == 0.09999999999999998  # (color, black)
 
     # test mROCAUC
-    assert mean_rocauc.shape == (np.unique(label_metadata[:, 2]).size,)
-    assert (
-        mean_rocauc == np.array([0.8009259259259259, 0.43125])  # animal, color
-    ).all()
+    assert mean_rocauc == 0.8009259259259259
 
 
-def test_rocauc_with_example(
-    classifications_two_categories: list[Classification],
+def test_compute_rocauc_colors():
+    """
+    Test ROC auc computation. This agrees with scikit-learn: the code (whose data
+    comes from classification_test_data)
+
+    color_gts = ["white", "white", "red", "blue", "black", "red"]
+    color_preds = [
+        {"white": 0.65, "red": 0.1, "blue": 0.2, "black": 0.05},
+        {"blue": 0.5, "white": 0.3, "red": 0.0, "black": 0.2},
+        {"red": 0.4, "white": 0.2, "blue": 0.1, "black": 0.3},
+        {"white": 1.0, "red": 0.0, "blue": 0.0, "black": 0.0},
+        {"red": 0.8, "white": 0.0, "blue": 0.2, "black": 0.0},
+        {"red": 0.9, "white": 0.06, "blue": 0.01, "black": 0.03},
+    ]
+
+    ```
+    from sklearn.metrics import roc_auc_score
+
+    # for the "color" label key
+    y_true = [3, 0, 2, 1, 0, 2]
+    y_score = [
+        [0.05, 0.2, 0.1, 0.65],
+        [0.2, 0.5, 0.0, 0.3],
+        [0.3, 0.1, 0.4, 0.2],
+        [0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.2, 0.8, 0.0],
+        [0.03, 0.01, 0.9, 0.06],
+    ]
+    ```
+
+    outputs:
+
+    ```
+    0.43125
+    ```
+    """
+
+    # groundtruth, prediction, score
+    colors = np.array(
+        [
+            [3, 2, 0, 1, 1],
+            [5, 1, 1, 0.9, 1],
+            [4, 3, 1, 0.8, 1],
+            [0, 0, 0, 0.65, 1],
+            [1, 0, 2, 0.5, 1],
+            [2, 1, 1, 0.4, 1],
+            [1, 0, 0, 0.3, 0],
+            [2, 1, 3, 0.3, 0],
+            [2, 1, 0, 0.2, 0],
+            [0, 0, 2, 0.2, 0],
+            [4, 3, 2, 0.2, 0],
+            [1, 0, 3, 0.2, 0],
+            [0, 0, 1, 0.1, 0],
+            [2, 1, 2, 0.1, 0],
+            [5, 1, 0, 0.06, 0],
+            [0, 0, 3, 0.05, 0],
+            [5, 1, 3, 0.03, 0],
+            [5, 1, 2, 0.01, 0],
+            [4, 3, 0, 0, 0],
+            [1, 0, 1, 0, 0],
+            [3, 2, 1, 0, 0],
+            [3, 2, 2, 0, 0],
+            [3, 2, 3, 0, 0],
+            [4, 3, 3, 0, 0],
+        ],
+        dtype=np.float64,
+    )
+    indices = np.argsort(-colors[:, 3], axis=0)
+    colors = colors[indices]
+
+    # create args
+    label_metadata = np.array(
+        [
+            [2, 6],
+            [2, 6],
+            [1, 6],
+            [1, 6],
+        ],
+        dtype=np.int32,
+    )
+
+    # compute ROCAUC and mROCAUC
+    (_, _, _, _, _, rocauc, mean_rocauc) = compute_metrics(
+        data=colors,
+        label_metadata=label_metadata,
+        n_datums=6,
+        score_thresholds=np.array([]),
+        hardmax=False,
+    )
+
+    # test ROCAUC
+    assert rocauc.shape == (label_metadata.shape[0],)
+    assert rocauc[0] == 0.75  # (color, white)
+    assert rocauc[1] == 0.875  # (color, red)
+    assert rocauc[2] == 0.0  # (color, blue)
+    assert rocauc[3] == 0.09999999999999998  # (color, black)
+
+    # test mROCAUC
+    assert mean_rocauc == 0.43125
+
+
+def test_rocauc_with_animal_example(
+    classifications_animal_example: list[Classification],
 ):
 
     loader = DataLoader()
-    loader.add_data(classifications_two_categories)
+    loader.add_data(classifications_animal_example)
     evaluator = loader.finalize()
 
     metrics = evaluator.evaluate(as_dict=True)
@@ -179,49 +220,21 @@ def test_rocauc_with_example(
             "type": "ROCAUC",
             "value": 0.7777777777777778,
             "parameters": {
-                "label": {"key": "animal", "value": "bird"},
+                "label": "bird",
             },
         },
         {
             "type": "ROCAUC",
             "value": 0.625,
             "parameters": {
-                "label": {"key": "animal", "value": "dog"},
+                "label": "dog",
             },
         },
         {
             "type": "ROCAUC",
             "value": 1.0,
             "parameters": {
-                "label": {"key": "animal", "value": "cat"},
-            },
-        },
-        {
-            "type": "ROCAUC",
-            "value": 0.75,
-            "parameters": {
-                "label": {"key": "color", "value": "white"},
-            },
-        },
-        {
-            "type": "ROCAUC",
-            "value": 0.875,
-            "parameters": {
-                "label": {"key": "color", "value": "red"},
-            },
-        },
-        {
-            "type": "ROCAUC",
-            "value": 0.0,
-            "parameters": {
-                "label": {"key": "color", "value": "blue"},
-            },
-        },
-        {
-            "type": "ROCAUC",
-            "value": 0.09999999999999998,
-            "parameters": {
-                "label": {"key": "color", "value": "black"},
+                "label": "cat",
             },
         },
     ]
@@ -233,20 +246,65 @@ def test_rocauc_with_example(
     # test mROCAUC
     actual_metrics = [m for m in metrics[MetricType.mROCAUC]]
     expected_metrics = [
+        {"type": "mROCAUC", "value": 0.8009259259259259, "parameters": {}},
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+
+def test_rocauc_with_color_example(
+    classifications_color_example: list[Classification],
+):
+
+    loader = DataLoader()
+    loader.add_data(classifications_color_example)
+    evaluator = loader.finalize()
+
+    metrics = evaluator.evaluate(as_dict=True, hardmax=False)
+
+    # test ROCAUC
+    actual_metrics = [m for m in metrics[MetricType.ROCAUC]]
+    expected_metrics = [
         {
-            "type": "mROCAUC",
-            "value": 0.8009259259259259,
+            "type": "ROCAUC",
+            "value": 0.75,
             "parameters": {
-                "label_key": "animal",
+                "label": "white",
             },
         },
         {
-            "type": "mROCAUC",
-            "value": 0.43125,
+            "type": "ROCAUC",
+            "value": 0.875,
             "parameters": {
-                "label_key": "color",
+                "label": "red",
             },
         },
+        {
+            "type": "ROCAUC",
+            "value": 0.0,
+            "parameters": {
+                "label": "blue",
+            },
+        },
+        {
+            "type": "ROCAUC",
+            "value": 0.09999999999999998,
+            "parameters": {
+                "label": "black",
+            },
+        },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
+
+    # test mROCAUC
+    actual_metrics = [m for m in metrics[MetricType.mROCAUC]]
+    expected_metrics = [
+        {"type": "mROCAUC", "value": 0.43125, "parameters": {}},
     ]
     for m in actual_metrics:
         assert m in expected_metrics
@@ -270,17 +328,7 @@ def test_rocauc_with_image_example(
         {
             "type": "ROCAUC",
             "value": 0.0,
-            "parameters": {"label": {"key": "k4", "value": "v4"}},
-        },
-        {
-            "type": "ROCAUC",
-            "value": 0.0,
-            "parameters": {"label": {"key": "k5", "value": "v5"}},
-        },
-        {
-            "type": "ROCAUC",
-            "value": 0.0,
-            "parameters": {"label": {"key": "k3", "value": "v3"}},
+            "parameters": {"label": "v4"},
         },
     ]
     for m in actual_metrics:
@@ -290,9 +338,7 @@ def test_rocauc_with_image_example(
 
     actual_metrics = [m for m in metrics[MetricType.mROCAUC]]
     expected_metrics = [
-        {"type": "mROCAUC", "value": 0.0, "parameters": {"label_key": "k3"}},
-        {"type": "mROCAUC", "value": 0.0, "parameters": {"label_key": "k4"}},
-        {"type": "mROCAUC", "value": 0.0, "parameters": {"label_key": "k5"}},
+        {"type": "mROCAUC", "value": 0.0, "parameters": {}},
     ]
     for m in actual_metrics:
         assert m in expected_metrics
@@ -316,17 +362,17 @@ def test_rocauc_with_tabular_example(
         {
             "type": "ROCAUC",
             "value": 0.75,
-            "parameters": {"label": {"key": "class", "value": "1"}},
+            "parameters": {"label": "1"},
         },
         {
             "type": "ROCAUC",
             "value": 1.0,
-            "parameters": {"label": {"key": "class", "value": "0"}},
+            "parameters": {"label": "0"},
         },
         {
             "type": "ROCAUC",
             "value": 0.5555555555555556,
-            "parameters": {"label": {"key": "class", "value": "2"}},
+            "parameters": {"label": "2"},
         },
     ]
     for m in actual_metrics:
@@ -339,7 +385,7 @@ def test_rocauc_with_tabular_example(
         {
             "type": "mROCAUC",
             "value": 0.7685185185185185,
-            "parameters": {"label_key": "class"},
+            "parameters": {},
         }
     ]
     for m in actual_metrics:

--- a/lite/tests/classification/test_schemas.py
+++ b/lite/tests/classification/test_schemas.py
@@ -6,8 +6,8 @@ def test_Classification():
 
     Classification(
         uid="uid",
-        groundtruths=[("k1", "v1")],
-        predictions=[("k1", "v1"), ("k1", "v1")],
+        groundtruths=["v1"],
+        predictions=["v1", "v2"],
         scores=[0.0, 1.0],
     )
 
@@ -15,7 +15,7 @@ def test_Classification():
     with pytest.raises(ValueError):
         Classification(
             uid="uid",
-            groundtruths=[("k1", "v1")],
-            predictions=[("k1", "v1"), ("k1", "v1")],
+            groundtruths=["v1"],
+            predictions=["v1", "v2"],
             scores=[0.0, 1.0, 0.0],
         )

--- a/lite/tests/classification/test_stability.py
+++ b/lite/tests/classification/test_stability.py
@@ -7,17 +7,14 @@ def generate_random_classifications(
     n_classifications: int, n_categories: int, n_labels: int
 ) -> list[Classification]:
 
-    labels = [
-        [(str(key), str(value)) for value in range(n_labels)]
-        for key in range(n_categories)
-    ]
+    labels = [str(value) for value in range(n_labels)]
 
     return [
         Classification(
             uid=f"uid{i}",
-            groundtruths=[choice(category) for category in labels],
-            predictions=[label for category in labels for label in category],
-            scores=[uniform(0, 1) for _ in range(n_labels * n_categories)],
+            groundtruths=[choice(labels)],
+            predictions=labels,
+            scores=[uniform(0, 1) for _ in range(n_labels)],
         )
         for i in range(n_classifications)
     ]
@@ -61,12 +58,10 @@ def test_fuzz_classifications_with_filtering():
         loader.add_data(classifications)
         evaluator = loader.finalize()
 
-        label_key = "1"
         datum_subset = [f"uid{i}" for i in range(len(classifications) // 2)]
 
         filter_ = evaluator.create_filter(
             datum_uids=datum_subset,
-            label_keys=[label_key],
         )
 
         evaluator.evaluate(

--- a/lite/valor_lite/classification/annotation.py
+++ b/lite/valor_lite/classification/annotation.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 @dataclass
 class Classification:
     uid: str
-    groundtruths: list[tuple[str, str]]
-    predictions: list[tuple[str, str]]
+    groundtruths: list[str]
+    predictions: list[str]
     scores: list[float]
 
     def __post_init__(self):

--- a/lite/valor_lite/classification/computation.py
+++ b/lite/valor_lite/classification/computation.py
@@ -59,7 +59,7 @@ def _compute_rocauc(
     rocauc = np.trapz(x=fpr, y=tpr, axis=1)  # type: ignore - numpy will be switching to `trapezoid` in the future.
 
     # compute mean rocauc
-    mean_rocauc = sum(rocauc) / n_labels
+    mean_rocauc = rocauc.mean()
 
     return rocauc, mean_rocauc
 

--- a/lite/valor_lite/classification/manager.py
+++ b/lite/valor_lite/classification/manager.py
@@ -560,7 +560,7 @@ class DataLoader:
     def _add_data(
         self,
         uid_index: int,
-        groundtruths: int,
+        groundtruth: int,
         predictions: list[tuple[int, float]],
     ):
 
@@ -572,7 +572,7 @@ class DataLoader:
             pairs.append(
                 (
                     float(uid_index),
-                    float(groundtruths),
+                    float(groundtruth),
                     float(plabel),
                     float(score),
                     float(max_score_idx == idx),
@@ -624,12 +624,12 @@ class DataLoader:
             uid_index = self._add_datum(uid=classification.uid)
 
             # cache labels and annotations
-            groundtruths = None
+            groundtruth = None
             predictions = list()
             for glabel in classification.groundtruths:
                 label_idx = self._add_label(glabel)
                 self.groundtruth_count[label_idx][uid_index] += 1
-                groundtruths = label_idx
+                groundtruth = label_idx
             for plabel, pscore in zip(
                 classification.predictions, classification.scores
             ):
@@ -644,14 +644,14 @@ class DataLoader:
 
             # fix type error where groundtruths can possibly be unbound now that it's a float
             # in practice, this error should never be hit since groundtruths can't be empty without throwing a ValueError earlier in the flow
-            if groundtruths is None:
+            if groundtruth is None:
                 raise ValueError(
                     "Expected a value for groundtruths, but got None."
                 )
 
             self._add_data(
                 uid_index=uid_index,
-                groundtruths=groundtruths,
+                groundtruth=groundtruth,
                 predictions=predictions,
             )
 
@@ -715,7 +715,7 @@ class DataLoader:
 
             self._add_data(
                 uid_index=uid_index,
-                groundtruths=groundtruths,
+                groundtruth=groundtruths,
                 predictions=predictions,
             )
 

--- a/lite/valor_lite/classification/manager.py
+++ b/lite/valor_lite/classification/manager.py
@@ -67,13 +67,8 @@ class Evaluator:
         self.index_to_uid: dict[int, str] = dict()
 
         # label reference
-        self.label_to_index: dict[tuple[str, str], int] = dict()
-        self.index_to_label: dict[int, tuple[str, str]] = dict()
-
-        # label key reference
-        self.index_to_label_key: dict[int, str] = dict()
-        self.label_key_to_index: dict[str, int] = dict()
-        self.label_index_to_label_key_index: dict[int, int] = dict()
+        self.label_to_index: dict[str, int] = dict()
+        self.index_to_label: dict[int, str] = dict()
 
         # computation caches
         self._detailed_pairs = np.array([])
@@ -81,7 +76,7 @@ class Evaluator:
         self._label_metadata_per_datum = np.array([], dtype=np.int32)
 
     @property
-    def ignored_prediction_labels(self) -> list[tuple[str, str]]:
+    def ignored_prediction_labels(self) -> list[str]:
         """
         Prediction labels that are not present in the ground truth set.
         """
@@ -92,7 +87,7 @@ class Evaluator:
         ]
 
     @property
-    def missing_prediction_labels(self) -> list[tuple[str, str]]:
+    def missing_prediction_labels(self) -> list[str]:
         """
         Ground truth labels that are not present in the prediction set.
         """
@@ -119,8 +114,7 @@ class Evaluator:
     def create_filter(
         self,
         datum_uids: list[str] | NDArray[np.int32] | None = None,
-        labels: list[tuple[str, str]] | NDArray[np.int32] | None = None,
-        label_keys: list[str] | NDArray[np.int32] | None = None,
+        labels: list[str] | NDArray[np.int32] | None = None,
     ) -> Filter:
         """
         Creates a boolean mask that can be passed to an evaluation.
@@ -129,10 +123,8 @@ class Evaluator:
         ----------
         datum_uids : list[str] | NDArray[np.int32], optional
             An optional list of string uids or a numpy array of uid indices.
-        labels : list[tuple[str, str]] | NDArray[np.int32], optional
+        labels : list[str] | NDArray[np.int32], optional
             An optional list of labels or a numpy array of label indices.
-        label_keys : list[str] | NDArray[np.int32], optional
-            An optional list of label keys or a numpy array of label key indices.
 
         Returns
         -------
@@ -179,36 +171,18 @@ class Evaluator:
             mask[labels] = True
             mask_labels &= mask
 
-        if label_keys is not None:
-            if isinstance(label_keys, list):
-                label_keys = np.array(
-                    [self.label_key_to_index[key] for key in label_keys]
-                )
-            label_indices = np.where(
-                np.isclose(self._label_metadata[:, 2], label_keys)
-            )[0]
-            mask = np.zeros_like(mask_pairs, dtype=np.bool_)
-            mask[
-                np.isin(self._detailed_pairs[:, 1].astype(int), label_indices)
-            ] = True
-            mask_pairs &= mask
-
-            mask = np.zeros_like(mask_labels, dtype=np.bool_)
-            mask[label_indices] = True
-            mask_labels &= mask
-
         mask = mask_datums[:, np.newaxis] & mask_labels[np.newaxis, :]
         label_metadata_per_datum = self._label_metadata_per_datum.copy()
         label_metadata_per_datum[:, ~mask] = 0
 
         label_metadata = np.zeros_like(self._label_metadata, dtype=np.int32)
-        label_metadata[:, :2] = np.transpose(
+        label_metadata = np.transpose(
             np.sum(
                 label_metadata_per_datum,
                 axis=1,
             )
         )
-        label_metadata[:, 2] = self._label_metadata[:, 2]
+
         n_datums = int(np.sum(label_metadata[:, 0]))
 
         return Filter(
@@ -288,10 +262,8 @@ class Evaluator:
 
         metrics[MetricType.mROCAUC] = [
             mROCAUC(
-                value=mean_rocauc[label_key_idx],
-                label_key=self.index_to_label_key[label_key_idx],
+                value=mean_rocauc,
             )
-            for label_key_idx in range(len(self.label_key_to_index))
         ]
 
         for label_idx, label in self.index_to_label.items():
@@ -367,7 +339,6 @@ class Evaluator:
     def _unpack_confusion_matrix(
         self,
         confusion_matrix: NDArray[np.floating],
-        label_key_idx: int,
         number_of_labels: int,
         number_of_examples: int,
     ) -> dict[
@@ -407,8 +378,8 @@ class Evaluator:
         )
 
         return {
-            self.index_to_label[gt_label_idx][1]: {
-                self.index_to_label[pd_label_idx][1]: {
+            self.index_to_label[gt_label_idx]: {
+                self.index_to_label[pd_label_idx]: {
                     "count": max(
                         int(confusion_matrix[gt_label_idx, pd_label_idx, 0]),
                         0,
@@ -430,22 +401,13 @@ class Evaluator:
                     ],
                 }
                 for pd_label_idx in range(number_of_labels)
-                if (
-                    self.label_index_to_label_key_index[pd_label_idx]
-                    == label_key_idx
-                )
             }
             for gt_label_idx in range(number_of_labels)
-            if (
-                self.label_index_to_label_key_index[gt_label_idx]
-                == label_key_idx
-            )
         }
 
     def _unpack_missing_predictions(
         self,
         missing_predictions: NDArray[np.int32],
-        label_key_idx: int,
         number_of_labels: int,
         number_of_examples: int,
     ) -> dict[str, dict[str, int | list[dict[str, str]]]]:
@@ -463,7 +425,7 @@ class Evaluator:
         )
 
         return {
-            self.index_to_label[gt_label_idx][1]: {
+            self.index_to_label[gt_label_idx]: {
                 "count": max(
                     int(missing_predictions[gt_label_idx, 0]),
                     0,
@@ -479,10 +441,6 @@ class Evaluator:
                 ],
             }
             for gt_label_idx in range(number_of_labels)
-            if (
-                self.label_index_to_label_key_index[gt_label_idx]
-                == label_key_idx
-            )
         }
 
     def _compute_confusion_matrix(
@@ -512,7 +470,7 @@ class Evaluator:
         Returns
         -------
         list[ConfusionMatrix]
-            A list of ConfusionMatrix per label key.
+            A list of ConfusionMatrix objects.
         """
 
         if data.size == 0:
@@ -530,22 +488,18 @@ class Evaluator:
         return [
             ConfusionMatrix(
                 score_threshold=score_thresholds[score_idx],
-                label_key=label_key,
                 number_of_examples=number_of_examples,
                 confusion_matrix=self._unpack_confusion_matrix(
                     confusion_matrix=confusion_matrix[score_idx, :, :, :],
-                    label_key_idx=label_key_idx,
                     number_of_labels=n_labels,
                     number_of_examples=number_of_examples,
                 ),
                 missing_predictions=self._unpack_missing_predictions(
                     missing_predictions=missing_predictions[score_idx, :, :],
-                    label_key_idx=label_key_idx,
                     number_of_labels=n_labels,
                     number_of_examples=number_of_examples,
                 ),
             )
-            for label_key_idx, label_key in self.index_to_label_key.items()
             for score_idx in range(n_scores)
         ]
 
@@ -580,77 +534,50 @@ class DataLoader:
             self._evaluator.index_to_uid[index] = uid
         return self._evaluator.uid_to_index[uid]
 
-    def _add_label(self, label: tuple[str, str]) -> tuple[int, int]:
+    def _add_label(self, label: str) -> int:
         """
         Helper function for adding a label to the cache.
 
         Parameters
         ----------
-        label : tuple[str, str]
-            The label as a tuple in format (key, value).
+        label : str
+            A string representing a label.
 
         Returns
         -------
         int
             Label index.
-        int
-            Label key index.
         """
         label_id = len(self._evaluator.index_to_label)
-        label_key_id = len(self._evaluator.index_to_label_key)
         if label not in self._evaluator.label_to_index:
             self._evaluator.label_to_index[label] = label_id
             self._evaluator.index_to_label[label_id] = label
 
-            # update label key index
-            if label[0] not in self._evaluator.label_key_to_index:
-                self._evaluator.label_key_to_index[label[0]] = label_key_id
-                self._evaluator.index_to_label_key[label_key_id] = label[0]
-                label_key_id += 1
-
-            self._evaluator.label_index_to_label_key_index[
-                label_id
-            ] = self._evaluator.label_key_to_index[label[0]]
             label_id += 1
 
-        return (
-            self._evaluator.label_to_index[label],
-            self._evaluator.label_key_to_index[label[0]],
-        )
+        return self._evaluator.label_to_index[label]
 
     def _add_data(
         self,
         uid_index: int,
-        keyed_groundtruths: dict[int, int],
-        keyed_predictions: dict[int, list[tuple[int, float]]],
+        groundtruths: int,
+        predictions: list[tuple[int, float]],
     ):
-        gt_keys = set(keyed_groundtruths.keys())
-        pd_keys = set(keyed_predictions.keys())
-        joint_keys = gt_keys.intersection(pd_keys)
-
-        gt_unique_keys = gt_keys - pd_keys
-        pd_unique_keys = pd_keys - gt_keys
-        if gt_unique_keys or pd_unique_keys:
-            raise ValueError(
-                "Label keys must match between ground truths and predictions."
-            )
 
         pairs = list()
-        for key in joint_keys:
-            scores = np.array([score for _, score in keyed_predictions[key]])
-            max_score_idx = np.argmax(scores)
+        scores = np.array([score for _, score in predictions])
+        max_score_idx = np.argmax(scores)
 
-            glabel = keyed_groundtruths[key]
-            for idx, (plabel, score) in enumerate(keyed_predictions[key]):
-                pairs.append(
-                    (
-                        float(uid_index),
-                        float(glabel),
-                        float(plabel),
-                        float(score),
-                        float(max_score_idx == idx),
-                    )
+        for idx, (plabel, score) in enumerate(predictions):
+            pairs.append(
+                (
+                    float(uid_index),
+                    float(groundtruths),
+                    float(plabel),
+                    float(score),
+                    float(max_score_idx == idx),
                 )
+            )
 
         if self._evaluator._detailed_pairs.size == 0:
             self._evaluator._detailed_pairs = np.array(pairs)
@@ -682,6 +609,12 @@ class DataLoader:
         disable_tqdm = not show_progress
         for classification in tqdm(classifications, disable=disable_tqdm):
 
+            if (len(classification.groundtruths) == 0) or (
+                len(classification.predictions) == 0
+            ):
+                raise ValueError(
+                    "Classifications must contain at least one groundtruth and prediction."
+                )
             # update metadata
             self._evaluator.n_datums += 1
             self._evaluator.n_groundtruths += len(classification.groundtruths)
@@ -691,28 +624,35 @@ class DataLoader:
             uid_index = self._add_datum(uid=classification.uid)
 
             # cache labels and annotations
-            keyed_groundtruths = defaultdict(int)
-            keyed_predictions = defaultdict(list)
+            groundtruths = None
+            predictions = list()
             for glabel in classification.groundtruths:
-                label_idx, label_key_idx = self._add_label(glabel)
+                label_idx = self._add_label(glabel)
                 self.groundtruth_count[label_idx][uid_index] += 1
-                keyed_groundtruths[label_key_idx] = label_idx
-            for idx, (plabel, pscore) in enumerate(
-                zip(classification.predictions, classification.scores)
+                groundtruths = label_idx
+            for plabel, pscore in zip(
+                classification.predictions, classification.scores
             ):
-                label_idx, label_key_idx = self._add_label(plabel)
+                label_idx = self._add_label(plabel)
                 self.prediction_count[label_idx][uid_index] += 1
-                keyed_predictions[label_key_idx].append(
+                predictions.append(
                     (
                         label_idx,
                         pscore,
                     )
                 )
 
+            # fix type error where groundtruths can possibly be unbound now that it's a float
+            # in practice, this error should never be hit since groundtruths can't be empty without throwing a ValueError earlier in the flow
+            if groundtruths is None:
+                raise ValueError(
+                    "Expected a value for groundtruths, but got None."
+                )
+
             self._add_data(
                 uid_index=uid_index,
-                keyed_groundtruths=keyed_groundtruths,
-                keyed_predictions=keyed_predictions,
+                groundtruths=groundtruths,
+                predictions=predictions,
             )
 
     def add_data_from_valor_dict(
@@ -745,31 +685,38 @@ class DataLoader:
             uid_index = self._add_datum(uid=groundtruth["datum"]["uid"])
 
             # cache labels and annotations
-            keyed_groundtruths = defaultdict(int)
-            keyed_predictions = defaultdict(list)
+            predictions = list()
+            groundtruths = None
             for gann in groundtruth["annotations"]:
                 for valor_label in gann["labels"]:
-                    glabel = (valor_label["key"], valor_label["value"])
-                    label_idx, label_key_idx = self._add_label(glabel)
+                    glabel = f'{valor_label["key"]}_{valor_label["value"]}'
+                    label_idx = self._add_label(glabel)
                     self.groundtruth_count[label_idx][uid_index] += 1
-                    keyed_groundtruths[label_key_idx] = label_idx
+                    groundtruths = label_idx
             for pann in prediction["annotations"]:
                 for valor_label in pann["labels"]:
-                    plabel = (valor_label["key"], valor_label["value"])
+                    plabel = f'{valor_label["key"]}_{valor_label["value"]}'
                     pscore = valor_label["score"]
-                    label_idx, label_key_idx = self._add_label(plabel)
+                    label_idx = self._add_label(plabel)
                     self.prediction_count[label_idx][uid_index] += 1
-                    keyed_predictions[label_key_idx].append(
+                    predictions.append(
                         (
                             label_idx,
                             pscore,
                         )
                     )
 
+            # fix type error where groundtruths can possibly be unbound now that it's a float
+            # in practice, this error should never be hit since groundtruths can't be empty without throwing a ValueError earlier in the flow
+            if groundtruths is None:
+                raise ValueError(
+                    "Expected a value for groundtruths, but got None."
+                )
+
             self._add_data(
                 uid_index=uid_index,
-                keyed_groundtruths=keyed_groundtruths,
-                keyed_predictions=keyed_predictions,
+                groundtruths=groundtruths,
+                predictions=predictions,
             )
 
     def finalize(self) -> Evaluator:
@@ -822,7 +769,6 @@ class DataLoader:
                             1, :, label_idx
                         ]
                     ),
-                    self._evaluator.label_index_to_label_key_index[label_idx],
                 ]
                 for label_idx in range(n_labels)
             ],

--- a/lite/valor_lite/classification/metric.py
+++ b/lite/valor_lite/classification/metric.py
@@ -35,7 +35,7 @@ class Counts:
     tn: list[int]
     score_thresholds: list[float]
     hardmax: bool
-    label: tuple[str, str]
+    label: str
 
     @property
     def metric(self) -> Metric:
@@ -50,10 +50,7 @@ class Counts:
             parameters={
                 "score_thresholds": self.score_thresholds,
                 "hardmax": self.hardmax,
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
+                "label": self.label,
             },
         )
 
@@ -66,7 +63,7 @@ class _ThresholdValue:
     value: list[float]
     score_thresholds: list[float]
     hardmax: bool
-    label: tuple[str, str]
+    label: str
 
     @property
     def metric(self) -> Metric:
@@ -76,10 +73,7 @@ class _ThresholdValue:
             parameters={
                 "score_thresholds": self.score_thresholds,
                 "hardmax": self.hardmax,
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
+                "label": self.label,
             },
         )
 
@@ -106,19 +100,14 @@ class F1(_ThresholdValue):
 @dataclass
 class ROCAUC:
     value: float
-    label: tuple[str, str]
+    label: str
 
     @property
     def metric(self) -> Metric:
         return Metric(
             type=type(self).__name__,
             value=self.value,
-            parameters={
-                "label": {
-                    "key": self.label[0],
-                    "value": self.label[1],
-                },
-            },
+            parameters={"label": self.label},
         )
 
     def to_dict(self) -> dict:
@@ -128,16 +117,13 @@ class ROCAUC:
 @dataclass
 class mROCAUC:
     value: float
-    label_key: str
 
     @property
     def metric(self) -> Metric:
         return Metric(
             type=type(self).__name__,
             value=self.value,
-            parameters={
-                "label_key": self.label_key,
-            },
+            parameters={},
         )
 
     def to_dict(self) -> dict:
@@ -170,7 +156,6 @@ class ConfusionMatrix:
         ],
     ]
     score_threshold: float
-    label_key: str
     number_of_examples: int
 
     @property
@@ -183,7 +168,6 @@ class ConfusionMatrix:
             },
             parameters={
                 "score_threshold": self.score_threshold,
-                "label_key": self.label_key,
             },
         )
 


### PR DESCRIPTION
## Improvements
- Update `lite` tests and functions to no longer use label keys