### PR TITLE
Enforce Single Groundtruth in Lite

### DIFF
--- a/lite/tests/classification/conftest.py
+++ b/lite/tests/classification/conftest.py
@@ -7,7 +7,7 @@ def basic_classifications() -> list[Classification]:
     return [
         Classification(
             uid="uid0",
-            groundtruths=["0"],
+            groundtruth="0",
             predictions=[
                 "0",
                 "1",
@@ -18,7 +18,7 @@ def basic_classifications() -> list[Classification]:
         ),
         Classification(
             uid="uid1",
-            groundtruths=["0"],
+            groundtruth="0",
             predictions=[
                 "0",
                 "1",
@@ -29,7 +29,7 @@ def basic_classifications() -> list[Classification]:
         ),
         Classification(
             uid="uid2",
-            groundtruths=["3"],
+            groundtruth="3",
             predictions=[
                 "0",
                 "1",
@@ -57,7 +57,7 @@ def classifications_from_api_unit_tests() -> list[Classification]:
     return [
         Classification(
             uid="uid0",
-            groundtruths=["0"],
+            groundtruth="0",
             predictions=[
                 "0",
                 "1",
@@ -67,7 +67,7 @@ def classifications_from_api_unit_tests() -> list[Classification]:
         ),
         Classification(
             uid="uid1",
-            groundtruths=["0"],
+            groundtruth="0",
             predictions=[
                 "0",
                 "1",
@@ -77,7 +77,7 @@ def classifications_from_api_unit_tests() -> list[Classification]:
         ),
         Classification(
             uid="uid2",
-            groundtruths=["0"],
+            groundtruth="0",
             predictions=[
                 "0",
                 "1",
@@ -87,7 +87,7 @@ def classifications_from_api_unit_tests() -> list[Classification]:
         ),
         Classification(
             uid="uid3",
-            groundtruths=["1"],
+            groundtruth="1",
             predictions=[
                 "0",
                 "1",
@@ -97,7 +97,7 @@ def classifications_from_api_unit_tests() -> list[Classification]:
         ),
         Classification(
             uid="uid4",
-            groundtruths=["2"],
+            groundtruth="2",
             predictions=[
                 "0",
                 "1",
@@ -107,7 +107,7 @@ def classifications_from_api_unit_tests() -> list[Classification]:
         ),
         Classification(
             uid="uid5",
-            groundtruths=["2"],
+            groundtruth="2",
             predictions=[
                 "0",
                 "1",
@@ -134,7 +134,7 @@ def classifications_animal_example() -> list[Classification]:
     return [
         Classification(
             uid=f"uid{idx}",
-            groundtruths=[gt],
+            groundtruth=gt,
             predictions=list(pd.keys()),
             scores=list(pd.values()),
         )
@@ -157,7 +157,7 @@ def classifications_color_example() -> list[Classification]:
     return [
         Classification(
             uid=f"uid{idx}",
-            groundtruths=[gt],
+            groundtruth=gt,
             predictions=list(pd.keys()),
             scores=list(pd.values()),
         )
@@ -170,9 +170,7 @@ def classifications_image_example() -> list[Classification]:
     return [
         Classification(
             uid="uid5",
-            groundtruths=[
-                "v4",
-            ],
+            groundtruth="v4",
             predictions=[
                 "v1",
                 "v8",
@@ -181,9 +179,7 @@ def classifications_image_example() -> list[Classification]:
         ),
         Classification(
             uid="uid6",
-            groundtruths=[
-                "v4",
-            ],
+            groundtruth="v4",
             predictions=[
                 "v4",
                 "v5",
@@ -211,7 +207,7 @@ def classifications_tabular_example() -> list[Classification]:
     return [
         Classification(
             uid=f"uid{i}",
-            groundtruths=[str(gt_label)],
+            groundtruth=str(gt_label),
             predictions=[str(pd_label) for pd_label, _ in enumerate(pds)],
             scores=pds,
         )
@@ -222,23 +218,11 @@ def classifications_tabular_example() -> list[Classification]:
 
 
 @pytest.fixture
-def classifications_no_groundtruths() -> list[Classification]:
-    return [
-        Classification(
-            uid="uid1",
-            groundtruths=[],
-            predictions=["v1", "v2"],
-            scores=[0.8, 0.2],
-        )
-    ]
-
-
-@pytest.fixture
 def classifications_no_predictions() -> list[Classification]:
     return [
         Classification(
             uid="uid1",
-            groundtruths=["v1", "v2"],
+            groundtruth="v1",
             predictions=[],
             scores=[],
         )
@@ -250,7 +234,7 @@ def classifications_multiclass() -> list[Classification]:
     return [
         Classification(
             uid="uid0",
-            groundtruths=["cat"],
+            groundtruth="cat",
             predictions=[
                 "cat",
                 "dog",
@@ -264,7 +248,7 @@ def classifications_multiclass() -> list[Classification]:
         ),
         Classification(
             uid="uid1",
-            groundtruths=["bee"],
+            groundtruth="bee",
             predictions=[
                 "cat",
                 "dog",
@@ -278,7 +262,7 @@ def classifications_multiclass() -> list[Classification]:
         ),
         Classification(
             uid="uid2",
-            groundtruths=["cat"],
+            groundtruth="cat",
             predictions=[
                 "cat",
                 "dog",
@@ -292,7 +276,7 @@ def classifications_multiclass() -> list[Classification]:
         ),
         Classification(
             uid="uid3",
-            groundtruths=["bee"],
+            groundtruth="bee",
             predictions=[
                 "cat",
                 "dog",
@@ -306,7 +290,7 @@ def classifications_multiclass() -> list[Classification]:
         ),
         Classification(
             uid="uid4",
-            groundtruths=["dog"],
+            groundtruth="dog",
             predictions=[
                 "cat",
                 "dog",
@@ -328,7 +312,7 @@ def classifications_multiclass_true_negatives_check() -> (
     return [
         Classification(
             uid="uid1",
-            groundtruths=["ant"],
+            groundtruth="ant",
             predictions=["ant", "bee", "cat"],
             scores=[0.15, 0.48, 0.37],
         ),
@@ -340,7 +324,7 @@ def classifications_multiclass_zero_count() -> list[Classification]:
     return [
         Classification(
             uid="uid1",
-            groundtruths=["ant"],
+            groundtruth="ant",
             predictions=["ant", "bee", "cat"],
             scores=[0.15, 0.48, 0.37],
         )

--- a/lite/tests/classification/test_dataloader.py
+++ b/lite/tests/classification/test_dataloader.py
@@ -28,22 +28,11 @@ def test_valor_integration():
     assert loader._evaluator.n_datums == 1
 
 
-def test_missing_groundtruths_or_predictions(
-    classifications_no_groundtruths: list[Classification],
+def test_missing_predictions(
     classifications_no_predictions: list[Classification],
 ):
     loader = DataLoader()
 
     with pytest.raises(ValueError) as e:
-        loader.add_data(classifications_no_groundtruths)
-    assert (
-        "Classifications must contain at least one groundtruth and prediction"
-        in str(e)
-    )
-
-    with pytest.raises(ValueError) as e:
         loader.add_data(classifications_no_predictions)
-    assert (
-        "Classifications must contain at least one groundtruth and prediction"
-        in str(e)
-    )
+    assert "Classifications must contain at least one prediction" in str(e)

--- a/lite/tests/classification/test_filtering.py
+++ b/lite/tests/classification/test_filtering.py
@@ -51,7 +51,7 @@ def generate_random_classifications(
     return [
         Classification(
             uid=f"uid{i}",
-            groundtruths=[choice(labels)],
+            groundtruth=choice(labels),
             predictions=labels,
             scores=[uniform(0, 1) for _ in range(n_labels)],
         )

--- a/lite/tests/classification/test_schemas.py
+++ b/lite/tests/classification/test_schemas.py
@@ -6,16 +6,25 @@ def test_Classification():
 
     Classification(
         uid="uid",
-        groundtruths=["v1"],
+        groundtruth="v1",
         predictions=["v1", "v2"],
         scores=[0.0, 1.0],
     )
+
+    # test that a groundtruth must be defined
+    with pytest.raises(ValueError):
+        Classification(
+            uid="uid",
+            groundtruth=[],  # type: ignore - testing
+            predictions=["v1", "v2"],
+            scores=[0.0, 1.0],
+        )
 
     # test that predictions must be of the same length as scores
     with pytest.raises(ValueError):
         Classification(
             uid="uid",
-            groundtruths=["v1"],
+            groundtruth="v1",
             predictions=["v1", "v2"],
             scores=[0.0, 1.0, 0.0],
         )

--- a/lite/tests/classification/test_stability.py
+++ b/lite/tests/classification/test_stability.py
@@ -12,7 +12,7 @@ def generate_random_classifications(
     return [
         Classification(
             uid=f"uid{i}",
-            groundtruths=[choice(labels)],
+            groundtruth=choice(labels),
             predictions=labels,
             scores=[uniform(0, 1) for _ in range(n_labels)],
         )

--- a/lite/tests/detection/test_schemas.py
+++ b/lite/tests/detection/test_schemas.py
@@ -76,7 +76,7 @@ def test_Bitmask():
     assert box
     assert box.extrema == (0, 4, 0, 4)
 
-    empty_box = Bitmask(mask=np.array([]), labels=["label"])
+    empty_box = Bitmask(mask=np.array([], dtype=np.bool_), labels=["label"])
 
     assert empty_box.to_box() is None
 

--- a/lite/tests/detection/test_stability.py
+++ b/lite/tests/detection/test_stability.py
@@ -9,15 +9,13 @@ def _generate_random_detections(
     def bbox(is_prediction):
         xmin, ymin = uniform(0, 10), uniform(0, 10)
         xmax, ymax = uniform(xmin, 15), uniform(ymin, 15)
-        kw = (
-            {"scores": [uniform(0, 1), uniform(0, 1)]} if is_prediction else {}
-        )
+        kw = {"scores": [uniform(0, 1)]} if is_prediction else {}
         return BoundingBox(
             xmin,
             xmax,
             ymin,
             ymax,
-            [choice(labels), choice(labels)],
+            [choice(labels)],
             **kw,
         )
 

--- a/lite/valor_lite/classification/annotation.py
+++ b/lite/valor_lite/classification/annotation.py
@@ -4,10 +4,14 @@ from dataclasses import dataclass
 @dataclass
 class Classification:
     uid: str
-    groundtruths: list[str]
+    groundtruth: str
     predictions: list[str]
     scores: list[float]
 
     def __post_init__(self):
+        if not isinstance(self.groundtruth, str):
+            raise ValueError(
+                "A classification must contain a single groundtruth."
+            )
         if len(self.predictions) != len(self.scores):
             raise ValueError("There must be a score per prediction label.")

--- a/lite/valor_lite/detection/annotation.py
+++ b/lite/valor_lite/detection/annotation.py
@@ -17,7 +17,7 @@ class BoundingBox:
     def __post_init__(self):
         if len(self.scores) == 0 and len(self.labels) != 1:
             raise ValueError(
-                "If no scores are defined, then this is a ground truth and a single label requirement is enforced."
+                "Ground truths must be defined with no scores and a single label. If you meant to define a prediction, then please include one score for every label provided."
             )
         if len(self.scores) > 0 and len(self.labels) != len(self.scores):
             raise ValueError(
@@ -41,7 +41,7 @@ class Polygon:
 
         if len(self.scores) == 0 and len(self.labels) != 1:
             raise ValueError(
-                "If no scores are defined, then this is a ground truth and a single label requirement is enforced."
+                "Ground truths must be defined with no scores and a single label. If you meant to define a prediction, then please include one score for every label provided."
             )
         if len(self.scores) > 0 and len(self.labels) != len(self.scores):
             raise ValueError(
@@ -83,7 +83,7 @@ class Bitmask:
 
         if len(self.scores) == 0 and len(self.labels) != 1:
             raise ValueError(
-                "If no scores are defined, then this is a ground truth and a single label requirement is enforced."
+                "Ground truths must be defined with no scores and a single label. If you meant to define a prediction, then please include one score for every label provided."
             )
         if len(self.scores) > 0 and len(self.labels) != len(self.scores):
             raise ValueError(

--- a/lite/valor_lite/detection/annotation.py
+++ b/lite/valor_lite/detection/annotation.py
@@ -15,6 +15,10 @@ class BoundingBox:
     scores: list[float] = field(default_factory=list)
 
     def __post_init__(self):
+        if len(self.scores) == 0 and len(self.labels) != 1:
+            raise ValueError(
+                "If no scores are defined, then this is a ground truth and a single label requirement is enforced."
+            )
         if len(self.scores) > 0 and len(self.labels) != len(self.scores):
             raise ValueError(
                 "If scores are defined, there must be a 1:1 pairing with labels."

--- a/lite/valor_lite/detection/annotation.py
+++ b/lite/valor_lite/detection/annotation.py
@@ -38,6 +38,11 @@ class Polygon:
     def __post_init__(self):
         if not isinstance(self.shape, ShapelyPolygon):
             raise TypeError("shape must be of type shapely.geometry.Polygon.")
+
+        if len(self.scores) == 0 and len(self.labels) != 1:
+            raise ValueError(
+                "If no scores are defined, then this is a ground truth and a single label requirement is enforced."
+            )
         if len(self.scores) > 0 and len(self.labels) != len(self.scores):
             raise ValueError(
                 "If scores are defined, there must be a 1:1 pairing with labels."
@@ -67,6 +72,19 @@ class Bitmask:
     scores: list[float] = field(default_factory=list)
 
     def __post_init__(self):
+
+        if (
+            not isinstance(self.mask, np.ndarray)
+            or self.mask.dtype != np.bool_
+        ):
+            raise ValueError(
+                "Expected mask to be of type `NDArray[np.bool_]`."
+            )
+
+        if len(self.scores) == 0 and len(self.labels) != 1:
+            raise ValueError(
+                "If no scores are defined, then this is a ground truth and a single label requirement is enforced."
+            )
         if len(self.scores) > 0 and len(self.labels) != len(self.scores):
             raise ValueError(
                 "If scores are defined, there must be a 1:1 pairing with labels."


### PR DESCRIPTION
Since we've removed label keys in detection and classification there should never be a condition where multiple groundtruths exist per annotation. 

# Changes
- Enforce a single label on ground truth annotations for detection and classification.