### PR TITLE
New MistralAI breaks Text Generation evaluation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
             "tqdm",
             "packaging",
             "openai",
-            "mistralai>=1.0",
+            "mistralai>=1.0,<1.8.0",
             "nltk",
             "rouge_score",
             "evaluate",

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 nlp = ["evaluate", "nltk", "rouge_score"]
-mistral = ["mistralai >= 1.0"]
+mistral = ["mistralai>=1.0.0,<1.8.0"]
 openai = ["openai"]
 docs = [
     "mkdocs",


### PR DESCRIPTION
- Lock `mistralai` dependency to `>=1.0.0,<1.8.0`