### PR TITLE
handle overlapped segmentations more gracefully

### DIFF
--- a/tests/semantic_segmentation/test_annotation.py
+++ b/tests/semantic_segmentation/test_annotation.py
@@ -131,6 +131,22 @@ def test_segmentation():
         shape=(1, 2),
     )
 
+    # wrong annotation type
+    with pytest.raises(ValueError):
+        Segmentation(
+            uid="uid",
+            groundtruths=[{"a": 1}],  # type: ignore - testing
+            predictions=[],
+            shape=(1, 2),
+        )
+    with pytest.raises(ValueError):
+        Segmentation(
+            uid="uid",
+            groundtruths=[],
+            predictions=[{"a": 1}],  # type: ignore - testing
+            shape=(1, 2),
+        )
+
 
 def test_segmentation_shape():
     Segmentation(uid="uid", groundtruths=[], predictions=[], shape=(1, 1))

--- a/tests/semantic_segmentation/test_annotation.py
+++ b/tests/semantic_segmentation/test_annotation.py
@@ -181,7 +181,7 @@ def test_segmentations_overlap():
         )
     assert (
         str(e._list[0].message)
-        == "ground truth masks for datum 'uid123' had 5000 / 10000 pixels overlapped."
+        == "groundtruths for datum 'uid123' had 5000 / 10000 pixels overlapped."
     )
     assert bitmask0.mask.sum() == 5000
     assert (
@@ -198,7 +198,7 @@ def test_segmentations_overlap():
         )
     assert (
         str(e._list[0].message)
-        == "prediction masks for datum 'uid123' had 5000 / 10000 pixels overlapped."
+        == "predictions for datum 'uid123' had 5000 / 10000 pixels overlapped."
     )
     assert bitmask0.mask.sum() == 5000
     assert (

--- a/tests/semantic_segmentation/test_annotation.py
+++ b/tests/semantic_segmentation/test_annotation.py
@@ -197,7 +197,7 @@ def test_segmentations_overlap():
         )
     assert (
         str(e._list[0].message)
-        == "groundtruths for datum 'uid123' had 5000 / 10000 pixels overlapped."
+        == "ground truth masks for datum 'uid123' had 5000 / 10000 pixels overlapped."
     )
     assert bitmask0.mask.sum() == 5000
     assert (
@@ -214,7 +214,7 @@ def test_segmentations_overlap():
         )
     assert (
         str(e._list[0].message)
-        == "predictions for datum 'uid123' had 5000 / 10000 pixels overlapped."
+        == "prediction masks for datum 'uid123' had 5000 / 10000 pixels overlapped."
     )
     assert bitmask0.mask.sum() == 5000
     assert (

--- a/tests/semantic_segmentation/test_annotation.py
+++ b/tests/semantic_segmentation/test_annotation.py
@@ -105,54 +105,6 @@ def test_segmentation():
         )
     assert "Received mask with shape '(1, 2)'" in str(e)
 
-    # test ground truths cannot overlap
-    with pytest.raises(ValueError) as e:
-        Segmentation(
-            uid="uid",
-            groundtruths=[
-                Bitmask(
-                    mask=np.array([[True, True, True]]),
-                    label="label1",
-                ),
-                Bitmask(
-                    mask=np.array([[False, False, True]]),
-                    label="label2",
-                ),
-            ],
-            predictions=[
-                Bitmask(
-                    mask=np.array([[True, False, False]]),
-                    label="label",
-                )
-            ],
-            shape=(1, 3),
-        )
-    assert "ground truth masks cannot overlap" in str(e)
-
-    # test predictions cannot overlap
-    with pytest.raises(ValueError) as e:
-        Segmentation(
-            uid="uid",
-            groundtruths=[
-                Bitmask(
-                    mask=np.array([[True, True, True]]),
-                    label="label1",
-                ),
-            ],
-            predictions=[
-                Bitmask(
-                    mask=np.array([[True, False, True]]),
-                    label="label",
-                ),
-                Bitmask(
-                    mask=np.array([[False, False, True]]),
-                    label="label2",
-                ),
-            ],
-            shape=(1, 3),
-        )
-    assert "prediction masks cannot overlap" in str(e)
-
     # allow missing ground truths
     Segmentation(
         uid="uid",


### PR DESCRIPTION
Instead of raising an error, segmentations with overlapped masks now operate on a first-come-first-serve basis in which the first label to arrive "claims" a pixel. The total number of affected pixels is counted and then conveyed in a warning after all labels have been checked.