### PR TITLE
Remove prediction suppression

### DIFF
--- a/src/valor_lite/object_detection/computation.py
+++ b/src/valor_lite/object_detection/computation.py
@@ -345,12 +345,6 @@ def rank_pairs(
     mask_unmatched_predictions = ~np.isin(pairs[:, 2], matched_predictions)
     pairs = pairs[mask_label_match | mask_unmatched_predictions]
 
-    # remove predictions for labels that have no ground truths
-    for label_idx, count in enumerate(label_metadata[:, 0]):
-        if count > 0:
-            continue
-        pairs = pairs[pairs[:, 4] != label_idx]
-
     # only keep the highest ranked pair
     _, indices = np.unique(pairs[:, [0, 2, 4]], axis=0, return_index=True)
     pairs = pairs[indices]

--- a/src/valor_lite/object_detection/utilities.py
+++ b/src/valor_lite/object_detection/utilities.py
@@ -48,7 +48,6 @@ def unpack_precision_recall_into_metric_lists(
         )
         for iou_idx, iou_threshold in enumerate(iou_thresholds)
         for label_idx, label in enumerate(index_to_label)
-        if int(label_metadata[label_idx, 0]) > 0
     ]
 
     metrics[MetricType.mAP] = [
@@ -67,7 +66,6 @@ def unpack_precision_recall_into_metric_lists(
             label=label,
         )
         for label_idx, label in enumerate(index_to_label)
-        if int(label_metadata[label_idx, 0]) > 0
     ]
 
     # TODO - (c.zaloom) will be removed in the future
@@ -87,7 +85,6 @@ def unpack_precision_recall_into_metric_lists(
         )
         for score_idx, score_threshold in enumerate(score_thresholds)
         for label_idx, label in enumerate(index_to_label)
-        if int(label_metadata[label_idx, 0]) > 0
     ]
 
     metrics[MetricType.mAR] = [
@@ -108,7 +105,6 @@ def unpack_precision_recall_into_metric_lists(
             label=label,
         )
         for label_idx, label in enumerate(index_to_label)
-        if int(label_metadata[label_idx, 0]) > 0
     ]
 
     # TODO - (c.zaloom) will be removed in the future

--- a/tests/object_detection/test_average_precision.py
+++ b/tests/object_detection/test_average_precision.py
@@ -379,6 +379,22 @@ def test_ap_using_torch_metrics_example(
         },
         {
             "type": "AP",
+            "value": 0.0,
+            "parameters": {
+                "iou_threshold": 0.5,
+                "label": "3",
+            },
+        },
+        {
+            "type": "AP",
+            "value": 0.0,
+            "parameters": {
+                "iou_threshold": 0.75,
+                "label": "3",
+            },
+        },
+        {
+            "type": "AP",
             "value": 1.0,
             "parameters": {
                 "iou_threshold": 0.5,
@@ -420,14 +436,14 @@ def test_ap_using_torch_metrics_example(
     expected_metrics = [
         {
             "type": "mAP",
-            "value": 0.8591859185918592,
+            "value": 0.715988265493216,
             "parameters": {
                 "iou_threshold": 0.5,
             },
         },
         {
             "type": "mAP",
-            "value": 0.7606789250353607,
+            "value": 0.6338991041961339,
             "parameters": {
                 "iou_threshold": 0.75,
             },
@@ -735,6 +751,22 @@ def test_ap_ranked_pair_ordering(
                 "value": 0.0,
                 "type": "AP",
             },
+            {
+                "parameters": {
+                    "iou_threshold": 0.5,
+                    "label": "label4",
+                },
+                "value": 0.0,
+                "type": "AP",
+            },
+            {
+                "parameters": {
+                    "iou_threshold": 0.75,
+                    "label": "label4",
+                },
+                "value": 0.0,
+                "type": "AP",
+            },
         ]
         for m in actual_metrics:
             assert m in expected_metrics
@@ -745,12 +777,12 @@ def test_ap_ranked_pair_ordering(
         expected_metrics = [
             {
                 "parameters": {"iou_threshold": 0.5},
-                "value": 0.6666666666666666,
+                "value": 0.5,
                 "type": "mAP",
             },
             {
                 "parameters": {"iou_threshold": 0.75},
-                "value": 0.6666666666666666,
+                "value": 0.5,
                 "type": "mAP",
             },
         ]
@@ -787,6 +819,14 @@ def test_ap_ranked_pair_ordering(
                 "value": 0.0,
                 "type": "APAveragedOverIOUs",
             },
+            {
+                "parameters": {
+                    "iou_thresholds": [0.5, 0.75],
+                    "label": "label4",
+                },
+                "value": 0.0,
+                "type": "APAveragedOverIOUs",
+            },
         ]
         for m in actual_metrics:
             assert m in expected_metrics
@@ -804,7 +844,7 @@ def test_ap_ranked_pair_ordering(
                         0.75,
                     ],
                 },
-                "value": 0.6666666666666666,
+                "value": 0.5,
                 "type": "mAPAveragedOverIOUs",
             },
         ]

--- a/tests/object_detection/test_average_recall.py
+++ b/tests/object_detection/test_average_recall.py
@@ -333,24 +333,6 @@ def test_ar_using_torch_metrics_example(
     expected_metrics = [
         {
             "type": "AR",
-            "value": 0.45,
-            "parameters": {
-                "iou_thresholds": iou_thresholds,
-                "score_threshold": 0.0,
-                "label": "2",
-            },
-        },
-        {
-            "type": "AR",
-            "value": 0.5800000000000001,
-            "parameters": {
-                "iou_thresholds": iou_thresholds,
-                "score_threshold": 0.0,
-                "label": "49",
-            },
-        },
-        {
-            "type": "AR",
             "value": 0.78,
             "parameters": {
                 "iou_thresholds": iou_thresholds,
@@ -369,11 +351,38 @@ def test_ar_using_torch_metrics_example(
         },
         {
             "type": "AR",
+            "value": 0.45,
+            "parameters": {
+                "iou_thresholds": iou_thresholds,
+                "score_threshold": 0.0,
+                "label": "2",
+            },
+        },
+        {
+            "type": "AR",
+            "value": 0.0,
+            "parameters": {
+                "iou_thresholds": iou_thresholds,
+                "score_threshold": 0.0,
+                "label": "3",
+            },
+        },
+        {
+            "type": "AR",
             "value": 0.65,
             "parameters": {
                 "iou_thresholds": iou_thresholds,
                 "score_threshold": 0.0,
                 "label": "4",
+            },
+        },
+        {
+            "type": "AR",
+            "value": 0.5800000000000001,
+            "parameters": {
+                "iou_thresholds": iou_thresholds,
+                "score_threshold": 0.0,
+                "label": "49",
             },
         },
     ]
@@ -387,7 +396,7 @@ def test_ar_using_torch_metrics_example(
     expected_metrics = [
         {
             "type": "mAR",
-            "value": 0.652,
+            "value": 0.5433333333333333,
             "parameters": {
                 "iou_thresholds": iou_thresholds,
                 "score_threshold": 0.0,
@@ -406,24 +415,6 @@ def test_ar_using_torch_metrics_example(
     expected_metrics = [
         {
             "type": "ARAveragedOverScores",
-            "value": 0.45,
-            "parameters": {
-                "iou_thresholds": iou_thresholds,
-                "score_thresholds": [0.0],
-                "label": "2",
-            },
-        },
-        {
-            "type": "ARAveragedOverScores",
-            "value": 0.5800000000000001,
-            "parameters": {
-                "iou_thresholds": iou_thresholds,
-                "score_thresholds": [0.0],
-                "label": "49",
-            },
-        },
-        {
-            "type": "ARAveragedOverScores",
             "value": 0.78,
             "parameters": {
                 "iou_thresholds": iou_thresholds,
@@ -442,11 +433,38 @@ def test_ar_using_torch_metrics_example(
         },
         {
             "type": "ARAveragedOverScores",
+            "value": 0.45,
+            "parameters": {
+                "iou_thresholds": iou_thresholds,
+                "score_thresholds": [0.0],
+                "label": "2",
+            },
+        },
+        {
+            "type": "ARAveragedOverScores",
+            "value": 0.0,
+            "parameters": {
+                "iou_thresholds": iou_thresholds,
+                "score_thresholds": [0.0],
+                "label": "3",
+            },
+        },
+        {
+            "type": "ARAveragedOverScores",
             "value": 0.65,
             "parameters": {
                 "iou_thresholds": iou_thresholds,
                 "score_thresholds": [0.0],
                 "label": "4",
+            },
+        },
+        {
+            "type": "ARAveragedOverScores",
+            "value": 0.5800000000000001,
+            "parameters": {
+                "iou_thresholds": iou_thresholds,
+                "score_thresholds": [0.0],
+                "label": "49",
             },
         },
     ]
@@ -462,7 +480,7 @@ def test_ar_using_torch_metrics_example(
     expected_metrics = [
         {
             "type": "mARAveragedOverScores",
-            "value": 0.652,
+            "value": 0.5433333333333333,
             "parameters": {
                 "iou_thresholds": iou_thresholds,
                 "score_thresholds": [0.0],
@@ -580,6 +598,15 @@ def test_ar_ranked_pair_ordering(
                     "label": "label3",
                 },
             },
+            {
+                "type": "AR",
+                "value": 0.0,
+                "parameters": {
+                    "score_threshold": 0.0,
+                    "iou_thresholds": [0.5, 0.75],
+                    "label": "label4",
+                },
+            },
         ]
         for m in actual_metrics:
             assert m in expected_metrics
@@ -590,7 +617,7 @@ def test_ar_ranked_pair_ordering(
         expected_metrics = expected_metrics = [
             {
                 "type": "mAR",
-                "value": 0.6666666666666666,
+                "value": 0.5,
                 "parameters": {
                     "score_threshold": 0.0,
                     "iou_thresholds": [0.5, 0.75],

--- a/tests/object_detection/test_evaluator.py
+++ b/tests/object_detection/test_evaluator.py
@@ -89,8 +89,19 @@ def test_no_groundtruths(detections_no_groundtruths):
         iou_thresholds=[0.5],
         score_thresholds=[0.5],
     )
-
-    assert len(metrics[MetricType.AP]) == 0
+    actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
+    assert len(actual_metrics) == 1
+    expected_metrics = [
+        {
+            "type": "AP",
+            "parameters": {"iou_threshold": 0.5, "label": "v1"},
+            "value": 0.0,
+        },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
 
 
 def test_no_predictions(detections_no_predictions):

--- a/tests/object_detection/test_filtering.py
+++ b/tests/object_detection/test_filtering.py
@@ -586,7 +586,23 @@ def test_filtering_all_detections(four_detections: list[Detection]):
         filter_=filter_,
     )
     actual_metrics = [m.to_dict() for m in metrics[MetricType.AP]]
-    assert len(actual_metrics) == 0
+    assert len(actual_metrics) == 2
+    expected_metrics = [
+        {
+            "type": "AP",
+            "parameters": {"iou_threshold": 0.5, "label": "v1"},
+            "value": 0.0,
+        },
+        {
+            "type": "AP",
+            "parameters": {"iou_threshold": 0.5, "label": "v2"},
+            "value": 0.0,
+        },
+    ]
+    for m in actual_metrics:
+        assert m in expected_metrics
+    for m in expected_metrics:
+        assert m in actual_metrics
 
 
 def test_filtering_random_detections():


### PR DESCRIPTION
# Issue
Average Precision and Average Recall are currently not computed for labels that are not used in the ground truth set. This is potentially problematic as a model could be highly confident in a label that is present in the real-world but not in the evaluation set leading to a suppression of information.

# Severity
LOW - This is likely not going to affect any existing evaluations as label sets are generally well-represented in training and validation sets. However, this could greatly affect one-off evaluations over sets of smaller data.

# Solution
Remove suppression and update AP and AR derivative metrics.
- AP, mAP, APAveragedOverIOUS, mAPAveragedOverIOUs
- AR, mAR, ARAveragedOverScores, mARAveragedOverScores